### PR TITLE
[LANDMARK ROUTING PART 3] SWMAAS-1331 Landmark Routing is now functional for Turn by Turn example

### DIFF
--- a/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
+++ b/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
@@ -16,7 +16,8 @@
 		9A28B1DC235A466600215476 /* ManeuverPresenterTextOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1DB235A466600215476 /* ManeuverPresenterTextOptions.swift */; };
 		9A28B1DE235A5F0F00215476 /* UIImage+Maneuver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1DD235A5F0F00215476 /* UIImage+Maneuver.swift */; };
 		9A28B1E5235DFC5900215476 /* CLLocationDistance+Maneuver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1E4235DFC5900215476 /* CLLocationDistance+Maneuver.swift */; };
-		9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Substitution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Substitution.swift */; };
+		9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */; };
+		9A28B1EF235E0CB400215476 /* LandmarkManeuverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1EE235E0CB400215476 /* LandmarkManeuverViewModel.swift */; };
 		9AA804942358BFC700B21924 /* PWFloorChangePOI+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA804932358BFC700B21924 /* PWFloorChangePOI+Extension.swift */; };
 		9AA80496235902AA00B21924 /* Maneuver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA80495235902AA00B21924 /* Maneuver.swift */; };
 		9D1ECD2A2225DE0C0029A667 /* BluedotLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1ECD292225DE0C0029A667 /* BluedotLocationViewController.swift */; };
@@ -63,7 +64,8 @@
 		9A28B1DB235A466600215476 /* ManeuverPresenterTextOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManeuverPresenterTextOptions.swift; sourceTree = "<group>"; };
 		9A28B1DD235A5F0F00215476 /* UIImage+Maneuver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Maneuver.swift"; sourceTree = "<group>"; };
 		9A28B1E4235DFC5900215476 /* CLLocationDistance+Maneuver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationDistance+Maneuver.swift"; sourceTree = "<group>"; };
-		9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Substitution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Substitution.swift"; sourceTree = "<group>"; };
+		9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
+		9A28B1EE235E0CB400215476 /* LandmarkManeuverViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LandmarkManeuverViewModel.swift; sourceTree = "<group>"; };
 		9AA804932358BFC700B21924 /* PWFloorChangePOI+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PWFloorChangePOI+Extension.swift"; sourceTree = "<group>"; };
 		9AA80495235902AA00B21924 /* Maneuver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Maneuver.swift; sourceTree = "<group>"; };
 		9CB47B3A056D6CD629EBD3CA /* Pods-MapScenarios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapScenarios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapScenarios/Pods-MapScenarios.debug.xcconfig"; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				9A15A446235A16E100C9AC06 /* ManeuverViewModel.swift */,
 				9A28B1DB235A466600215476 /* ManeuverPresenterTextOptions.swift */,
 				9A15A448235A173000C9AC06 /* StandardManeuverViewModel.swift */,
+				9A28B1EE235E0CB400215476 /* LandmarkManeuverViewModel.swift */,
 			);
 			path = Maneuver;
 			sourceTree = "<group>";
@@ -200,7 +203,7 @@
 				E378581C221313500059A179 /* PWRoute+Helper.swift */,
 				E378583B222821B10059A179 /* UIColor+Helper.swift */,
 				9AA804932358BFC700B21924 /* PWFloorChangePOI+Extension.swift */,
-				9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Substitution.swift */,
+				9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */,
 			);
 			name = Extensions;
 			path = MapScenarios/Extensions;
@@ -458,7 +461,7 @@
 				9D1ECD2C2225DE1C0029A667 /* WalkTimeViewController.swift in Sources */,
 				E3C3799C204D90AA00905731 /* AppDelegate.swift in Sources */,
 				9A15A447235A16E100C9AC06 /* ManeuverViewModel.swift in Sources */,
-				9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Substitution.swift in Sources */,
+				9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Extension.swift in Sources */,
 				E378582E222073CA0059A179 /* TurnByTurnInstructionCollectionViewCell.swift in Sources */,
 				9AA80496235902AA00B21924 /* Maneuver.swift in Sources */,
 				E3C771CF2050846E00780D0F /* SearchPOIViewController.swift in Sources */,
@@ -466,6 +469,7 @@
 				E3785836222735A80059A179 /* RouteInstructionListViewController.swift in Sources */,
 				E3785826221706680059A179 /* VoicePromptButton.swift in Sources */,
 				E37858212216FB840059A179 /* MKMapPoint+Helper.swift in Sources */,
+				9A28B1EF235E0CB400215476 /* LandmarkManeuverViewModel.swift in Sources */,
 				E378583C222821B10059A179 /* UIColor+Helper.swift in Sources */,
 				E378581F22145F500059A179 /* PWMapView+Helper.swift in Sources */,
 				E3C76E7E204DF6B600780D0F /* LocationModesViewController.swift in Sources */,

--- a/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
+++ b/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		7EFF9C6222330740002BDD0A /* OffRouteModalView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7EFF9C6122330740002BDD0A /* OffRouteModalView.xib */; };
 		9A15A447235A16E100C9AC06 /* ManeuverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15A446235A16E100C9AC06 /* ManeuverViewModel.swift */; };
 		9A15A449235A173000C9AC06 /* StandardManeuverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15A448235A173000C9AC06 /* StandardManeuverViewModel.swift */; };
-		9A28B1DC235A466600215476 /* ManeuverPresenterTextOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1DB235A466600215476 /* ManeuverPresenterTextOptions.swift */; };
+		9A28B1DC235A466600215476 /* ManeuverTextOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1DB235A466600215476 /* ManeuverTextOptions.swift */; };
 		9A28B1DE235A5F0F00215476 /* UIImage+Maneuver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1DD235A5F0F00215476 /* UIImage+Maneuver.swift */; };
 		9A28B1E5235DFC5900215476 /* CLLocationDistance+Maneuver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1E4235DFC5900215476 /* CLLocationDistance+Maneuver.swift */; };
 		9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */; };
@@ -61,7 +61,7 @@
 		7EFF9C6122330740002BDD0A /* OffRouteModalView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OffRouteModalView.xib; sourceTree = "<group>"; };
 		9A15A446235A16E100C9AC06 /* ManeuverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManeuverViewModel.swift; sourceTree = "<group>"; };
 		9A15A448235A173000C9AC06 /* StandardManeuverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardManeuverViewModel.swift; sourceTree = "<group>"; };
-		9A28B1DB235A466600215476 /* ManeuverPresenterTextOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManeuverPresenterTextOptions.swift; sourceTree = "<group>"; };
+		9A28B1DB235A466600215476 /* ManeuverTextOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManeuverTextOptions.swift; sourceTree = "<group>"; };
 		9A28B1DD235A5F0F00215476 /* UIImage+Maneuver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Maneuver.swift"; sourceTree = "<group>"; };
 		9A28B1E4235DFC5900215476 /* CLLocationDistance+Maneuver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationDistance+Maneuver.swift"; sourceTree = "<group>"; };
 		9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
@@ -150,7 +150,7 @@
 				9A28B1DF235A60ED00215476 /* Extensions */,
 				9AA80495235902AA00B21924 /* Maneuver.swift */,
 				9A15A446235A16E100C9AC06 /* ManeuverViewModel.swift */,
-				9A28B1DB235A466600215476 /* ManeuverPresenterTextOptions.swift */,
+				9A28B1DB235A466600215476 /* ManeuverTextOptions.swift */,
 				9A15A448235A173000C9AC06 /* StandardManeuverViewModel.swift */,
 				9A28B1EE235E0CB400215476 /* LandmarkManeuverViewModel.swift */,
 			);
@@ -474,7 +474,7 @@
 				E378581F22145F500059A179 /* PWMapView+Helper.swift in Sources */,
 				E3C76E7E204DF6B600780D0F /* LocationModesViewController.swift in Sources */,
 				9D1ECD2A2225DE0C0029A667 /* BluedotLocationViewController.swift in Sources */,
-				9A28B1DC235A466600215476 /* ManeuverPresenterTextOptions.swift in Sources */,
+				9A28B1DC235A466600215476 /* ManeuverTextOptions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/MapScenarios/MapScenarios/Extensions/NSMutableAttributedString+Extension.swift
+++ b/Samples/MapScenarios/MapScenarios/Extensions/NSMutableAttributedString+Extension.swift
@@ -1,5 +1,5 @@
 //
-//  NSMutableAttributedString+Substitution.swift
+//  NSMutableAttributedString+Extension.swift
 //  MapScenarios
 //
 //  Created by Aaron Pendley on 10/21/19.
@@ -15,5 +15,16 @@ extension NSMutableAttributedString {
             let replacement = NSAttributedString(string: replacement, attributes: attributes)
             self.replaceCharacters(in: nsRange, with: replacement)
         }
+    }
+    
+    var lastAttributes: [NSAttributedString.Key : Any]? {
+        var last: [NSAttributedString.Key : Any]? = nil
+
+        enumerateAttributes(in: .init(location: 0, length: length), options: .reverse) { (attributes, range, stop) in
+            last = attributes
+            stop.pointee = true
+        }
+        
+        return last
     }
 }

--- a/Samples/MapScenarios/MapScenarios/Maneuver/LandmarkManeuverViewModel.swift
+++ b/Samples/MapScenarios/MapScenarios/Maneuver/LandmarkManeuverViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  StandardManeuverViewModel.swift
+//  LandmarkManeuverViewModel.swift
 //  MapScenarios
 //
 //  Created by Aaron Pendley on 10/18/19.
@@ -7,10 +7,12 @@
 //
 
 import Foundation
+
+import Foundation
 import UIKit
 import PWMapKit
 
-struct StandardManeuverViewModel {
+struct LandmarkManeuverViewModel {
     private let maneuver: Maneuver
     private let standardOptions: ManeuverPresenterTextOptions
     private let highlightOptions: ManeuverPresenterTextOptions
@@ -24,7 +26,7 @@ struct StandardManeuverViewModel {
     }
 }
 
-extension StandardManeuverViewModel: ManeuverViewModel {
+extension LandmarkManeuverViewModel: ManeuverViewModel {
     var image: UIImage {
         return .image(for: maneuver)
     }
@@ -52,41 +54,95 @@ extension StandardManeuverViewModel: ManeuverViewModel {
     private var baseAttributedStringForManeuver: NSMutableAttributedString {
         switch maneuver.maneuverType {
         case .straight:
-            let templateString = NSLocalizedString("$0 for $1", comment: "$0 = direction, $1 = distance")
-            let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
-            
-            let straightString = NSLocalizedString("Go straight", comment: "")
-            attributed.replace(substring: "$0", with: straightString, attributes: highlightOptions.attributes)
-            
-            let distanceString = maneuver.instruction.distance.localizedStringForManeuver
-            attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
-            return attributed
-            
-        case .turn(let direction):
-            let templateString = NSLocalizedString("$0 in $1", comment: "$0 = direction, $1 = distance")
-            let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
-            
-            let turnString: String
-            
-            switch direction {
-            case .left:
-                turnString = NSLocalizedString("Turn left", comment: "")
-            case .right:
-                turnString = NSLocalizedString("Turn right", comment: "")
-            case .bearLeft:
-                turnString = NSLocalizedString("Bear left", comment: "")
-            case .bearRight:
-                turnString = NSLocalizedString("Bear right", comment: "")
-            default:
-                // should never happen
-                turnString = ""
+            if let landmark = maneuver.instruction.landmarks?.last {
+                let templateString = NSLocalizedString("$0 for $1 towards $2", comment: "$0 = direction, $1 = distance, $2 = landmark")
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                let straightString = NSLocalizedString("Go straight", comment: "")
+                attributed.replace(substring: "$0", with: straightString, attributes: highlightOptions.attributes)
+                
+                let distanceString = maneuver.instruction.distance.localizedStringForManeuver
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                
+                attributed.replace(substring: "$2", with: landmark.name, attributes: highlightOptions.attributes)
+                
+                return attributed
+            } else {
+                let templateString = NSLocalizedString("$0 for $1", comment: "$0 = direction, $1 = distance")
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                let straightString = NSLocalizedString("Go straight", comment: "")
+                attributed.replace(substring: "$0", with: straightString, attributes: highlightOptions.attributes)
+                
+                let distanceString = maneuver.instruction.distance.localizedStringForManeuver
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                
+                return attributed
             }
             
-            attributed.replace(substring: "$0", with: turnString, attributes: highlightOptions.attributes)
-            
-            let distanceString = maneuver.instruction.distance.localizedStringForManeuver
-            attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
-            return attributed
+        case .turn(let direction):
+            if let landmark = maneuver.instruction.landmarks?.last {
+                let templateString = NSLocalizedString("$0 in $1 $2 $3", comment: "$0 = direction, $1 = distance, $2 = at/after, $3 = landmark name")
+                
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                let turnString: String
+                
+                switch direction {
+                case .left:
+                    turnString = NSLocalizedString("Turn left", comment: "")
+                case .right:
+                    turnString = NSLocalizedString("Turn right", comment: "")
+                case .bearLeft:
+                    turnString = NSLocalizedString("Bear left", comment: "")
+                case .bearRight:
+                    turnString = NSLocalizedString("Bear right", comment: "")
+                default:
+                    // should never happen
+                    turnString = ""
+                }
+                
+                attributed.replace(substring: "$0", with: turnString, attributes: highlightOptions.attributes)
+                
+                let distanceString = maneuver.instruction.distance.localizedStringForManeuver
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                
+                let positionString = (landmark.position == .at)
+                    ? NSLocalizedString("at", comment: "")
+                    : NSLocalizedString("after", comment: "")
+                
+                attributed.replace(substring: "$2", with: positionString, attributes: standardOptions.attributes)
+                
+                attributed.replace(substring: "$3", with: landmark.name, attributes: highlightOptions.attributes)
+                
+                return attributed
+                
+            } else {
+                let templateString = NSLocalizedString("$0 in $1", comment: "$0 = direction, $1 = distance")
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                let turnString: String
+                
+                switch direction {
+                case .left:
+                    turnString = NSLocalizedString("Turn left", comment: "")
+                case .right:
+                    turnString = NSLocalizedString("Turn right", comment: "")
+                case .bearLeft:
+                    turnString = NSLocalizedString("Bear left", comment: "")
+                case .bearRight:
+                    turnString = NSLocalizedString("Bear right", comment: "")
+                default:
+                    // should never happen
+                    turnString = ""
+                }
+                
+                attributed.replace(substring: "$0", with: turnString, attributes: highlightOptions.attributes)
+                
+                let distanceString = maneuver.instruction.distance.localizedStringForManeuver
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                return attributed
+            }
             
         case .upcomingFloorChange(let floorChange):
             let templateString = NSLocalizedString("Continue $0 towards $1 to $2", comment: "$0 = distance, $1 floor change type, $2 = floor name")

--- a/Samples/MapScenarios/MapScenarios/Maneuver/LandmarkManeuverViewModel.swift
+++ b/Samples/MapScenarios/MapScenarios/Maneuver/LandmarkManeuverViewModel.swift
@@ -14,12 +14,12 @@ import PWMapKit
 
 struct LandmarkManeuverViewModel {
     private let maneuver: Maneuver
-    private let standardOptions: ManeuverPresenterTextOptions
-    private let highlightOptions: ManeuverPresenterTextOptions
+    private let standardOptions: ManeuverTextOptions
+    private let highlightOptions: ManeuverTextOptions
     
     init(for instruction: PWRouteInstruction,
-         standardOptions: ManeuverPresenterTextOptions = .defaultStandardOptions,
-         highlightOptions: ManeuverPresenterTextOptions = .defaultHighlightOptions) {
+         standardOptions: ManeuverTextOptions = .defaultStandardOptions,
+         highlightOptions: ManeuverTextOptions = .defaultHighlightOptions) {
         self.maneuver = Maneuver(for: instruction)
         self.standardOptions = standardOptions
         self.highlightOptions = highlightOptions

--- a/Samples/MapScenarios/MapScenarios/Maneuver/LandmarkManeuverViewModel.swift
+++ b/Samples/MapScenarios/MapScenarios/Maneuver/LandmarkManeuverViewModel.swift
@@ -188,7 +188,6 @@ extension LandmarkManeuverViewModel: ManeuverViewModel {
                 floorChangeString = NSLocalizedString("floor change", comment: "")
             }
             
-            
             attributed.replace(substring: "$0", with: floorChangeString, attributes: highlightOptions.attributes)
             
             let directionString: String

--- a/Samples/MapScenarios/MapScenarios/Maneuver/ManeuverTextOptions.swift
+++ b/Samples/MapScenarios/MapScenarios/Maneuver/ManeuverTextOptions.swift
@@ -1,5 +1,5 @@
 //
-//  ManeuverPresenterTextOptions.swift
+//  ManeuverTextOptions.swift
 //  MapScenarios
 //
 //  Created by Aaron Pendley on 10/18/19.
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-struct ManeuverPresenterTextOptions {
+struct ManeuverTextOptions {
     let color: UIColor
     let font: UIFont
     
@@ -18,10 +18,10 @@ struct ManeuverPresenterTextOptions {
     }
 }
 
-extension ManeuverPresenterTextOptions {
-    static let defaultStandardOptions = ManeuverPresenterTextOptions(color: .darkText,
+extension ManeuverTextOptions {
+    static let defaultStandardOptions = ManeuverTextOptions(color: .darkText,
                                                                      font: .systemFont(ofSize: 15.0, weight: .regular))
     
-    static let defaultHighlightOptions = ManeuverPresenterTextOptions(color: .nasa,
+    static let defaultHighlightOptions = ManeuverTextOptions(color: .nasa,
                                                                       font: .systemFont(ofSize: 15.0, weight: .bold))
 }

--- a/Samples/MapScenarios/MapScenarios/Maneuver/StandardManeuverViewModel.swift
+++ b/Samples/MapScenarios/MapScenarios/Maneuver/StandardManeuverViewModel.swift
@@ -132,7 +132,6 @@ extension StandardManeuverViewModel: ManeuverViewModel {
                 floorChangeString = NSLocalizedString("floor change", comment: "")
             }
             
-            
             attributed.replace(substring: "$0", with: floorChangeString, attributes: highlightOptions.attributes)
             
             let directionString: String

--- a/Samples/MapScenarios/MapScenarios/Maneuver/StandardManeuverViewModel.swift
+++ b/Samples/MapScenarios/MapScenarios/Maneuver/StandardManeuverViewModel.swift
@@ -12,12 +12,12 @@ import PWMapKit
 
 struct StandardManeuverViewModel {
     private let maneuver: Maneuver
-    private let standardOptions: ManeuverPresenterTextOptions
-    private let highlightOptions: ManeuverPresenterTextOptions
+    private let standardOptions: ManeuverTextOptions
+    private let highlightOptions: ManeuverTextOptions
     
     init(for instruction: PWRouteInstruction,
-         standardOptions: ManeuverPresenterTextOptions = .defaultStandardOptions,
-         highlightOptions: ManeuverPresenterTextOptions = .defaultHighlightOptions) {
+         standardOptions: ManeuverTextOptions = .defaultStandardOptions,
+         highlightOptions: ManeuverTextOptions = .defaultHighlightOptions) {
         self.maneuver = Maneuver(for: instruction)
         self.standardOptions = standardOptions
         self.highlightOptions = highlightOptions

--- a/Samples/MapScenarios/MapScenarios/Scenarios/Route Instruction List/RouteInstructionListViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/Route Instruction List/RouteInstructionListViewController.swift
@@ -14,10 +14,12 @@ class RouteInstructionListViewController: UIViewController {
     private var walkTimeView: WalkTimeView?
     private var mapView: PWMapView?
     private var displayedWalkTimeView: WalkTimeView?
+    private var enableLandmarkRouting: Bool = false
     
-    func configure(mapView: PWMapView, walkTimeView: WalkTimeView? = nil) {
+    func configure(mapView: PWMapView, enableLandmarkRouting: Bool = false, walkTimeView: WalkTimeView? = nil) {
         self.mapView = mapView
         self.displayedWalkTimeView = walkTimeView
+        self.enableLandmarkRouting = enableLandmarkRouting
         
         self.tableView.reloadData()
     }
@@ -118,7 +120,13 @@ extension RouteInstructionListViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as! RouteInstructionListCell
         
         if let routeInstruction = mapView?.currentRoute?.routeInstructions?[indexPath.row] {
-            cell.configure(with: StandardManeuverViewModel(for: routeInstruction))
+            // If landmark routing is enabled, use the LandmarkManeuverViewModel to provide instruction text using landmarks.
+            // Otherwise, use the StandardManeuverViewModel to provide default instruction text.
+            let viewModel: ManeuverViewModel = enableLandmarkRouting
+                ? LandmarkManeuverViewModel(for: routeInstruction)
+                : StandardManeuverViewModel(for: routeInstruction)
+            
+            cell.configure(with: viewModel)
         }
         
         return cell

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/Collection View/TurnByTurnCollectionView.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/Collection View/TurnByTurnCollectionView.swift
@@ -18,6 +18,7 @@ protocol TurnByTurnDelegate: class {
 class TurnByTurnCollectionView: UICollectionView {
     
     let mapView: PWMapView
+    let enableLandmarkRouting: Bool
     
     weak var turnByTurnDelegate: TurnByTurnDelegate?
     
@@ -47,8 +48,9 @@ class TurnByTurnCollectionView: UICollectionView {
     
     private var indexOfCellBeforeDragging = 0
     
-    init(mapView: PWMapView) {
+    init(mapView: PWMapView, enableLandmarkRouting: Bool = false) {
         self.mapView = mapView
+        self.enableLandmarkRouting = enableLandmarkRouting
         
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -72,6 +74,7 @@ class TurnByTurnCollectionView: UICollectionView {
     
     required init?(coder aDecoder: NSCoder) {
         mapView = PWMapView()
+        enableLandmarkRouting = false
         super.init(coder: aDecoder)
     }
     
@@ -138,7 +141,12 @@ extension TurnByTurnCollectionView: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as! TurnByTurnInstructionCollectionViewCell
         
         if let routeInstruction = mapView.currentRoute?.routeInstructions?[indexPath.row] {
-            let viewModel = StandardManeuverViewModel(for: routeInstruction)
+            // If landmark routing is enabled, use the LandmarkManeuverViewModel to provide instruction text using landmarks.
+            // Otherwise, use the StandardManeuverViewModel to provide default instruction text.
+            let viewModel: ManeuverViewModel = enableLandmarkRouting
+                ? LandmarkManeuverViewModel(for: routeInstruction)
+                : StandardManeuverViewModel(for: routeInstruction)
+            
             cell.configure(with: viewModel)
         }
         

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/TurnByTurnViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/TurnByTurnViewController.swift
@@ -91,10 +91,14 @@ class TurnByTurnViewController: UIViewController, TurnByTurnDelegate {
             return
         }
         
+        let routeOptions = PWRouteOptions(accessibilityEnabled: false,
+                                          landmarksEnabled: enableLandmarkRouting,
+                                          excludedPointIdentifiers: nil)
+        
         // Calculate a route and plot on the map
         PWRoute.createRoute(from: startPOI,
                             to: destinationPOI,
-                            options: nil,
+                            options: routeOptions,
                             completion: { [weak self] (route, error) in
             guard let route = route else {
                 self?.warning("Couldn't find a route between POI(\(self?.startPOIIdentifier ?? 0)) and POI(\(self?.destinationPOIIdentifier ?? 0)).")
@@ -113,7 +117,7 @@ class TurnByTurnViewController: UIViewController, TurnByTurnDelegate {
     func initializeTurnByTurn() {
         mapView.setRouteManeuver(mapView.currentRoute.routeInstructions.first)
         if turnByTurnCollectionView == nil {
-            turnByTurnCollectionView = TurnByTurnCollectionView(mapView: mapView)
+            turnByTurnCollectionView = TurnByTurnCollectionView(mapView: mapView, enableLandmarkRouting: enableLandmarkRouting)
             turnByTurnCollectionView?.turnByTurnDelegate = self
             turnByTurnCollectionView?.configureInView(view)
         }

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/TurnByTurnViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/TurnByTurnViewController.swift
@@ -128,7 +128,7 @@ class TurnByTurnViewController: UIViewController, TurnByTurnDelegate {
     
     func instructionExpandTapped() {
         let routeInstructionViewController = RouteInstructionListViewController()
-        routeInstructionViewController.configure(mapView: mapView)
+        routeInstructionViewController.configure(mapView: mapView, enableLandmarkRouting: enableLandmarkRouting)
         routeInstructionViewController.presentFromViewController(self)
     }
     

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/TurnByTurnViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurn/TurnByTurnViewController.swift
@@ -24,6 +24,9 @@ class TurnByTurnViewController: UIViewController, TurnByTurnDelegate {
     var startPOIIdentifier: Int = 0
     var destinationPOIIdentifier: Int = 0
     
+    // Set to 'true' to enable landmark routing
+    var enableLandmarkRouting = false
+    
     let mapView = PWMapView()
     
     var turnByTurnCollectionView: TurnByTurnCollectionView?


### PR DESCRIPTION
* Set the ‘landmarkRoutingEnabled’ flag to ‘true’ in TurnByTurnViewController to generate routes with landmark information (if available), and to use the LandmarkManueverViewModel to generate the instruction text that uses the landmark data.
* Set ‘landmarkRoutingEnabled’ flag to ‘false’ in TurnByTurnViewController to use default routing with no landmark information.
* Ideally I would have liked to create a whole new view controller and example for the landmark routing, however since so much functionality has been included in TurnByTurnCollectionView this is extremely difficult to do without a lot of refactoring. So, for the moment, we’ll add a flag that indicates whether landmark routing is enabled, and if so, it will use the LandmarkManeuverViewModel to generate the instruction text.
* These changes require the changes from the SWMAAS-1329 branch of PWMapKit