### PR TITLE
SWMAAS-1543 Add Turn By Turn instructions to Off Route scenario and some cleanup

### DIFF
--- a/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
+++ b/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
@@ -141,8 +141,8 @@
 		7E87A2F0222478DC004ABFE9 /* OffRoute */ = {
 			isa = PBXGroup;
 			children = (
-				7EFF9C5F2232FCD3002BDD0A /* OffRouteModalViewController.swift */,
 				7E87A2F1222478FF004ABFE9 /* OffRouteViewController.swift */,
+				7EFF9C5F2232FCD3002BDD0A /* OffRouteModalViewController.swift */,
 				7EFF9C6122330740002BDD0A /* OffRouteModalView.xib */,
 			);
 			path = OffRoute;

--- a/Samples/MapScenarios/MapScenarios/Scenarios/BluedotLocationViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/BluedotLocationViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import PWMapKit
 import PWCore
 
+// MARK: - BluedotLocationViewController
 class BluedotLocationViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -18,11 +19,12 @@ class BluedotLocationViewController: UIViewController, ScenarioSettingsProtocol 
     var accessKey = ""
     var signatureKey = ""
     
-    var buildingIdentifier = 0 // Enter your building identifier here, found on the building's Edit page on Maas portal
+    // Enter your building identifier here, found on the building's Edit page on Maas portal
+    var buildingIdentifier = 0
     
-    let mapView = PWMapView()
-    let locationManager = CLLocationManager()
-    var firstLocationAcquired = false
+    private let mapView = PWMapView()
+    private let locationManager = CLLocationManager()
+    private var firstLocationAcquired = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -70,7 +72,6 @@ class BluedotLocationViewController: UIViewController, ScenarioSettingsProtocol 
 }
 
 // MARK: - PWMapViewDelegate
-
 extension BluedotLocationViewController: PWMapViewDelegate {
     
     func mapView(_ mapView: PWMapView!, locationManager: PWLocationManager!, didUpdateIndoorUserLocation userLocation: PWUserLocation!) {
@@ -82,7 +83,6 @@ extension BluedotLocationViewController: PWMapViewDelegate {
 }
 
 // MARK: - CLLocationManagerDelegate
-
 extension BluedotLocationViewController: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {

--- a/Samples/MapScenarios/MapScenarios/Scenarios/CustomPOIViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/CustomPOIViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import PWMapKit
 import PWCore
 
+// MARK: - CustomPOIViewController
 class CustomPOIViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -18,9 +19,10 @@ class CustomPOIViewController: UIViewController, ScenarioSettingsProtocol {
     var accessKey = ""
     var signatureKey = ""
     
-    var buildingIdentifier = 0 // Enter your building identifier here, found on the building's Edit page on Maas portal
+    // Enter your building identifier here, found on the building's Edit page on Maas portal
+    var buildingIdentifier = 0
     
-    let mapView = PWMapView()
+    private let mapView = PWMapView()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Samples/MapScenarios/MapScenarios/Scenarios/LoadBuildingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/LoadBuildingViewController.swift
@@ -10,6 +10,7 @@ import Foundation
 import PWMapKit
 import PWCore
 
+// MARK: - LoadBuildingViewController
 class LoadBuildingViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -22,13 +23,13 @@ class LoadBuildingViewController: UIViewController, ScenarioSettingsProtocol {
     
     // The starting center coordinate for the camera view. Set this to be the location of your building
     // (or close to it) so that the camera will already be close to the building location before the building loads.
-    let initialCenterCoordinate = CLLocationCoordinate2D(latitude: 37.0902, longitude: -95.7129)
+    private let initialCenterCoordinate = CLLocationCoordinate2D(latitude: 37.0902, longitude: -95.7129)
     
     // The how many meters the camera will display of the map from the center point.
     // Set to a lower value if you would like the camera to start zoomed in more.
-    let initialCameraDistance: CLLocationDistance = 10000000
+    private let initialCameraDistance: CLLocationDistance = 10000000
     
-    let mapView = PWMapView()
+    private let mapView = PWMapView()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Samples/MapScenarios/MapScenarios/Scenarios/LocationModesViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/LocationModesViewController.swift
@@ -11,6 +11,115 @@ import UIKit
 import PWMapKit
 import PWCore
 
+// MARK: - LocationModesViewController
+class LocationModesViewController: UIViewController, ScenarioSettingsProtocol {
+    
+    // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
+    var applicationId = ""
+    var accessKey = ""
+    var signatureKey = ""
+    
+    // Enter your building identifier here, found on the building's Edit page on Maas portal
+    var buildingIdentifier = 0
+    
+    private let mapView = PWMapView()
+    private let locationManager = CLLocationManager()
+    
+    @IBOutlet weak var toolbar: UIToolbar!
+    @IBOutlet weak var trackingModeButton: UIBarButtonItem!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationItem.title = "Location Modes"
+        
+        if !validateScenarioSettings() {
+            return
+        }
+        
+        PWCore.setApplicationID(applicationId, accessKey: accessKey, signatureKey: signatureKey)
+        mapView.delegate = self
+        view.addSubview(mapView)
+        configureMapViewConstraints()
+        
+        trackingModeButton.image = .emptyTrackingImage(color: .blue)
+
+        PWBuilding.building(withIdentifier: buildingIdentifier) { [weak self] (building, error) in
+            self?.mapView.setBuilding(building, animated: true, onCompletion: { (error) in
+                self?.locationManager.delegate = self
+                if !CLLocationManager.isAuthorized() {
+                    self?.locationManager.requestWhenInUseAuthorization()
+                } else {
+                    self?.startManagedLocationManager()
+                }
+            })
+        }
+    }
+    
+    func startManagedLocationManager() {
+        DispatchQueue.main.async { [weak self] in
+            guard let buildingIdentifier = self?.buildingIdentifier else {
+                return
+            }
+            let managedLocationManager = PWManagedLocationManager(buildingId: buildingIdentifier)
+            self?.mapView.register(managedLocationManager)
+        }
+    }
+    
+    func configureMapViewConstraints() {
+        mapView.translatesAutoresizingMaskIntoConstraints = false
+        mapView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        mapView.bottomAnchor.constraint(equalTo: toolbar.topAnchor).isActive = true
+        mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+    }
+    
+    @IBAction func trackingModeButtonTapped(_ sender: Any) {
+        switch mapView.trackingMode {
+        case .none:
+            mapView.trackingMode = .follow
+        case .follow:
+            mapView.trackingMode = .followWithHeading
+        case .followWithHeading:
+            mapView.trackingMode = .none
+        @unknown default:
+            break
+        }
+    }
+}
+
+// MARK: - PWMapViewDelegate
+extension LocationModesViewController: PWMapViewDelegate {
+    
+    func mapView(_ mapView: PWMapView!, didChangeIndoorUserTrackingMode mode: PWTrackingMode) {
+        switch mode {
+        case .none:
+            trackingModeButton.image = .emptyTrackingImage(color: .blue)
+        case .follow:
+            trackingModeButton.image = .filledTrackingImage(color: .blue)
+        case .followWithHeading:
+            trackingModeButton.image = .trackWithHeadingImage(color: .blue)
+        @unknown default:
+            break
+        }
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+extension LocationModesViewController: CLLocationManagerDelegate {
+    
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            startManagedLocationManager()
+        default:
+            mapView.unregisterLocationManager()
+            print("Not authorized to start PWLocationManager")
+        }
+    }
+}
+
+// MARK: UIImage Extension
 extension UIImage {
     
     class func emptyTrackingImage(color: UIColor) -> UIImage {
@@ -101,113 +210,5 @@ extension UIImage {
             return image
         }
         return UIImage()
-    }
-}
-
-class LocationModesViewController: UIViewController, ScenarioSettingsProtocol {
-    
-    // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
-    var applicationId = ""
-    var accessKey = ""
-    var signatureKey = ""
-    
-    var buildingIdentifier = 0 // Enter your building identifier here, found on the building's Edit page on Maas portal
-    
-    let mapView = PWMapView()
-    let locationManager = CLLocationManager()
-    
-    @IBOutlet weak var toolbar: UIToolbar!
-    @IBOutlet weak var trackingModeButton: UIBarButtonItem!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        navigationItem.title = "Location Modes"
-        
-        if !validateScenarioSettings() {
-            return
-        }
-        
-        PWCore.setApplicationID(applicationId, accessKey: accessKey, signatureKey: signatureKey)
-        mapView.delegate = self
-        view.addSubview(mapView)
-        configureMapViewConstraints()
-        
-        trackingModeButton.image = .emptyTrackingImage(color: .blue)
-
-        PWBuilding.building(withIdentifier: buildingIdentifier) { [weak self] (building, error) in
-            self?.mapView.setBuilding(building, animated: true, onCompletion: { (error) in
-                self?.locationManager.delegate = self
-                if !CLLocationManager.isAuthorized() {
-                    self?.locationManager.requestWhenInUseAuthorization()
-                } else {
-                    self?.startManagedLocationManager()
-                }
-            })
-        }
-    }
-    
-    func startManagedLocationManager() {
-        DispatchQueue.main.async { [weak self] in
-            guard let buildingIdentifier = self?.buildingIdentifier else {
-                return
-            }
-            let managedLocationManager = PWManagedLocationManager(buildingId: buildingIdentifier)
-            self?.mapView.register(managedLocationManager)
-        }
-    }
-    
-    func configureMapViewConstraints() {
-        mapView.translatesAutoresizingMaskIntoConstraints = false
-        mapView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        mapView.bottomAnchor.constraint(equalTo: toolbar.topAnchor).isActive = true
-        mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-        mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-    }
-    
-    @IBAction func trackingModeButtonTapped(_ sender: Any) {
-        switch mapView.trackingMode {
-        case .none:
-            mapView.trackingMode = .follow
-        case .follow:
-            mapView.trackingMode = .followWithHeading
-        case .followWithHeading:
-            mapView.trackingMode = .none
-        @unknown default:
-            break
-        }
-    }
-}
-
-// MARK: - PWMapViewDelegate
-
-extension LocationModesViewController: PWMapViewDelegate {
-    
-    func mapView(_ mapView: PWMapView!, didChangeIndoorUserTrackingMode mode: PWTrackingMode) {
-        switch mode {
-        case .none:
-            trackingModeButton.image = .emptyTrackingImage(color: .blue)
-        case .follow:
-            trackingModeButton.image = .filledTrackingImage(color: .blue)
-        case .followWithHeading:
-            trackingModeButton.image = .trackWithHeadingImage(color: .blue)
-        @unknown default:
-            break
-        }
-    }
-}
-
-// MARK: - CLLocationManagerDelegate
-
-extension LocationModesViewController: CLLocationManagerDelegate {
-    
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        switch status {
-        case .authorizedAlways, .authorizedWhenInUse:
-            startManagedLocationManager()
-        default:
-            mapView.unregisterLocationManager()
-            print("Not authorized to start PWLocationManager")
-        }
     }
 }

--- a/Samples/MapScenarios/MapScenarios/Scenarios/LocationSharingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/LocationSharingViewController.swift
@@ -12,7 +12,6 @@ import PWMapKit
 import PWCore
 
 // MARK: - CGFloat extension
-
 extension CGFloat {
     
     static func random() -> CGFloat {
@@ -21,7 +20,6 @@ extension CGFloat {
 }
 
 // MARK: - SharedLocationAnnotation
-
 class SharedLocationAnnotation: MKPointAnnotation {
     
     var sharedLocation: PWSharedLocation!
@@ -32,12 +30,12 @@ class SharedLocationAnnotation: MKPointAnnotation {
     }
 }
 
-// MARK: - SharedLocationAnnotationView
-
+// MARK: - Notification
 extension Notification.Name {
     static let didUpdateAnnotation = Notification.Name("didUpdateAnnotation")
 }
 
+// MARK: - SharedLocationAnnotationView
 class SharedLocationAnnotationView: MKAnnotationView {
     
     let floatingTextLabel = UILabel()
@@ -73,7 +71,6 @@ class SharedLocationAnnotationView: MKAnnotationView {
 }
 
 // MARK: Floating Text Label
-
 extension SharedLocationAnnotationView {
     
     func configureFloatingTextLabel() {
@@ -101,7 +98,6 @@ extension SharedLocationAnnotationView {
 }
 
 // MARK: - LocationSharingViewController
-
 class LocationSharingViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -109,14 +105,15 @@ class LocationSharingViewController: UIViewController, ScenarioSettingsProtocol 
     var accessKey = ""
     var signatureKey = ""
     
-    var buildingIdentifier = 0 // Enter your building identifier here, found on the building's Edit page on Maas portal
+    // Enter your building identifier here, found on the building's Edit page on Maas portal
+    var buildingIdentifier = 0
     
-    let mapView = PWMapView()
-    let locationManager = CLLocationManager()
-    var firstLocationAcquired = false
+    private let mapView = PWMapView()
+    private let locationManager = CLLocationManager()
+    private var firstLocationAcquired = false
     
-    let deviceDisplayNameKey = "DeviceDisplayNameKey"
-    var deviceDisplayName: String {
+    private let deviceDisplayNameKey = "DeviceDisplayNameKey"
+    private var deviceDisplayName: String {
         get {
             if let displayName = UserDefaults.standard.object(forKey: deviceDisplayNameKey) as? String {
                 return displayName
@@ -129,8 +126,8 @@ class LocationSharingViewController: UIViewController, ScenarioSettingsProtocol 
         }
     }
     
-    let deviceTypeKey = "DeviceTypeKey"
-    var deviceType: String {
+    private let deviceTypeKey = "DeviceTypeKey"
+    private var deviceType: String {
         get {
             if let type = UserDefaults.standard.object(forKey: deviceTypeKey) as? String {
                 return type
@@ -143,10 +140,10 @@ class LocationSharingViewController: UIViewController, ScenarioSettingsProtocol 
         }
     }
     
-    var sharedLocations = Set<PWSharedLocation>()
-    var sharedLocationAnnotations = [String : SharedLocationAnnotation]()
+    private var sharedLocations = Set<PWSharedLocation>()
+    private var sharedLocationAnnotations = [String : SharedLocationAnnotation]()
     
-    var annotationColors = [String : UIColor]()
+    private var annotationColors = [String : UIColor]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -225,7 +222,6 @@ class LocationSharingViewController: UIViewController, ScenarioSettingsProtocol 
 }
 
 // MARK: - PWMapViewDelegate
-
 extension LocationSharingViewController: PWMapViewDelegate {
     
     func mapView(_ mapView: PWMapView!, locationManager: PWLocationManager!, didUpdateIndoorUserLocation userLocation: PWUserLocation!) {
@@ -247,7 +243,6 @@ extension LocationSharingViewController: PWMapViewDelegate {
 }
 
 // MARK: - PWLocationSharingDelegate
-
 extension LocationSharingViewController: PWLocationSharingDelegate {
     
     // Called when the shared locations are updated. Includes complete list of shared locations
@@ -300,7 +295,6 @@ extension LocationSharingViewController: PWLocationSharingDelegate {
 }
 
 // MARK: - CLLocationManagerDelegate
-
 extension LocationSharingViewController: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
@@ -315,7 +309,6 @@ extension LocationSharingViewController: CLLocationManagerDelegate {
 }
 
 // MARK: - Settings Button
-
 extension LocationSharingViewController {
     
     @objc func settingsTapped() {

--- a/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteModalViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteModalViewController.swift
@@ -8,16 +8,26 @@
 
 import UIKit
 
+// MARK: - OffRouteModalViewController
+protocol OffRouteModalViewControllerDelegate: class {
+    func offRouteAlert(_ alert: OffRouteModalViewController, dismissedWithResult result: OffRouteModalViewController.Result)
+}
+
+// MARK: - OffRouteModalViewController
 class OffRouteModalViewController: UIViewController {
 
     @IBOutlet weak var offRouteView: UIView!
     @IBOutlet weak var offRouteDismissButton: UIButton!
     @IBOutlet weak var offRouteRerouteButton: UIButton!
     @IBOutlet weak var offRouteDontShowAgainButton: UIButton!
-
-    var dismissCompletion : (() -> Void)?
-    var rerouteCompletion : (() -> Void)?
-    var dontShowAgainCompletion : (() -> Void)?
+    
+    enum Result {
+        case dismiss
+        case reroute
+        case dontShowAgain
+    }
+    
+    weak var delegate: OffRouteModalViewControllerDelegate?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,16 +42,18 @@ class OffRouteModalViewController: UIViewController {
     }
 
     @IBAction func dismissButtonClicked(sender: UIButton) {
-        dismissCompletion?()
-        self.dismiss(animated: true, completion: nil)
+        delegate?.offRouteAlert(self, dismissedWithResult: .dismiss)
+        dismiss(animated: true, completion: nil)
     }
+    
     @IBAction func rerouteButtonClicked(sender: UIButton) {
-        rerouteCompletion?()
-        self.dismiss(animated: true, completion: nil)
+        delegate?.offRouteAlert(self, dismissedWithResult: .reroute)
+        dismiss(animated: true, completion: nil)
     }
+    
     @IBAction func dontShowAgainButtonClicked(sender: UIButton) {
-        dontShowAgainCompletion?()
-        self.dismiss(animated: true, completion: nil)
+        delegate?.offRouteAlert(self, dismissedWithResult: .dontShowAgain)
+        dismiss(animated: true, completion: nil)
     }
 
 }

--- a/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
@@ -151,6 +151,10 @@ extension OffRouteViewController: PWMapViewDelegate {
             }
         }
     }
+    
+    func mapView(_ mapView: PWMapView!, didChange instruction: PWRouteInstruction!) {
+        turnByTurnCollectionView?.scrollToInstruction(instruction)
+    }
 }
 
 // MARK: - OffRouteModalViewControllerDelegate

--- a/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import PWCore
 import PWMapKit
 
+// MARK: - OffRouteViewController
 class OffRouteViewController: UIViewController, ScenarioSettingsProtocol {
 
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -17,23 +18,36 @@ class OffRouteViewController: UIViewController, ScenarioSettingsProtocol {
     var accessKey = ""
     var signatureKey = ""
 
-    var buildingIdentifier = 0 // Enter your building identifier here, found on the building's Edit page on Maas portal
+    // Enter your building identifier here, found on the building's Edit page on Maas portal
+    var buildingIdentifier = 0
 
-    let destinationPOIIdentifier = 0 /* Replace with the destination POI identifier */
+    // Replace with the destination POI identifier
+    private let destinationPOIIdentifier = 0
 
-
-    let mapView = PWMapView()
-    let locationManager = CLLocationManager()
-    var firstLocationAcquired = false
-    var currentRoute: PWRoute?
-    let offRouteDistanceThreshold: CLLocationDistance = 10.0 //distance in meters
-    let offRouteTimeThreshold: TimeInterval = 5.0 //time in seconds
-    var offRouteTimer: Timer? = nil
-    var showOffRouteMessageAgainTimer: Timer? = nil
-    var okToShowOffRouteMessageAgainAfterTimerCompletes = true
-    let okToShowOffRouteMessageAgainTimerThreshold = 10.0 //time in seconds
-    var modalVisible = false
-    var dontShowAgain = false
+    private let mapView = PWMapView()
+    private var turnByTurnCollectionView: TurnByTurnCollectionView?
+    
+    private let locationManager = CLLocationManager()
+    private var firstLocationAcquired = false
+    private var currentRoute: PWRoute?
+    
+    private let offRouteDistanceThreshold: CLLocationDistance = 10.0 //distance in meters
+    private let offRouteTimeThreshold: TimeInterval = 5.0 //time in seconds
+    private var offRouteTimer: Timer? = nil
+    
+    private let offRouteMessageCooldownInterval = 10.0 //time in seconds
+    private var lastTimeOffRouteMessageWasDismissed: Date?
+    
+    private var isOffRouteAlertCooldownActive: Bool {
+        guard let lastTime = lastTimeOffRouteMessageWasDismissed else {
+            return false
+        }
+        
+        return Date().timeIntervalSince(lastTime) < offRouteMessageCooldownInterval
+    }
+    
+    private var modalVisible = false
+    private var dontShowAgain = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -61,141 +75,25 @@ class OffRouteViewController: UIViewController, ScenarioSettingsProtocol {
             })
         }
     }
-
-    func startManagedLocationManager() {
-        DispatchQueue.main.async { [weak self] in
-            guard let buildingIdentifier = self?.buildingIdentifier else {
-                return
-            }
-            let managedLocationManager = PWManagedLocationManager(buildingId: buildingIdentifier)
-            self?.mapView.register(managedLocationManager)
-        }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        turnByTurnCollectionView?.isHidden = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        turnByTurnCollectionView?.isHidden = true
+        super.viewWillDisappear(animated)
     }
 
-    func configureMapViewConstraints() {
-        mapView.translatesAutoresizingMaskIntoConstraints = false
-        mapView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-        mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-    }
-
-    func buildRoute() {
-        dontShowAgain = false
-
-        var destinationPOI: PWPointOfInterest!
-        if destinationPOIIdentifier != 0 {
-            destinationPOI = mapView.building.pois.filter({
-                return $0.identifier == destinationPOIIdentifier
-            }).first
-        } else {
-            if let firstPOI = mapView.building.pois.first {
-                destinationPOI = firstPOI
-            }
-        }
-
-        if destinationPOI == nil {
-            print("No points of interest found, please add at least one to the building in the Maas portal")
-            return
-        }
-
-        // Calculate a route and plot on the map
-        PWRoute.createRoute(from: mapView.indoorUserLocation,
-                            to: destinationPOI,
-                            options: nil,
-                            completion: { [weak self] (route, error) in
-            if (route != nil) {
-                self?.currentRoute = route
-            } else {
-                print("Couldn't find a route from you current location to the destination.")
-                return
-            }
-
-            let routeOptions = PWRouteUIOptions()
-            self?.mapView.navigate(with: route, options: routeOptions)
-        })
-    }
-
-    @objc func fireTimer() {
+    @objc func offRouteTimerExpired() {
         offRouteTimer?.invalidate()
         offRouteTimer = nil
         showOffRouteMessage()
     }
-    
-    @objc func setOkToShowOffRouteMessageAgainAfterTimerCompletesToTrue() {
-        showOffRouteMessageAgainTimer?.invalidate()
-        showOffRouteMessageAgainTimer = nil
-        okToShowOffRouteMessageAgainAfterTimerCompletes = true
-    }
-
-    private func showOffRouteMessage() {
-        if (!modalVisible) {
-            modalVisible = true
-
-            let offRouteModal = OffRouteModalViewController()
-            offRouteModal.modalPresentationStyle = .overCurrentContext
-            offRouteModal.modalTransitionStyle = .crossDissolve
-
-            offRouteModal.dismissCompletion = { [weak self] in
-                self?.modalVisible = false
-            }
-
-            offRouteModal.rerouteCompletion = { [weak self] in
-                self?.modalVisible = false
-                self?.mapView.cancelRouting()
-                self?.currentRoute = nil
-                self?.buildRoute()
-            }
-
-            offRouteModal.dontShowAgainCompletion = { [weak self] in
-                self?.modalVisible = false
-                self?.dontShowAgain = true
-            }
-
-            present(offRouteModal, animated: true, completion: nil)
-            okToShowOffRouteMessageAgainAfterTimerCompletes = false
-            showOffRouteMessageAgainTimer = Timer.scheduledTimer(timeInterval: okToShowOffRouteMessageAgainTimerThreshold, target: self, selector: #selector(setOkToShowOffRouteMessageAgainAfterTimerCompletesToTrue), userInfo: nil, repeats: false)
-        }
-    }
-}
-
-// MARK: - PWMapViewDelegate
-
-extension OffRouteViewController: PWMapViewDelegate {
-
-    func mapView(_ mapView: PWMapView!, locationManager: PWLocationManager!, didUpdateIndoorUserLocation userLocation: PWUserLocation!) {
-        if !firstLocationAcquired {
-            firstLocationAcquired = true
-            mapView.trackingMode = .follow
-
-            self.buildRoute()
-        } else {
-            if !modalVisible, !dontShowAgain, okToShowOffRouteMessageAgainAfterTimerCompletes {
-                if let closestRouteInstruction = self.currentRoute?.closestInstructionTo(userLocation) {
-                    let distanceToRouteInstruction = MKMapPoint(userLocation.coordinate).distanceTo(closestRouteInstruction.polyline)
-                    if (distanceToRouteInstruction > 0.0) {
-                        if (distanceToRouteInstruction >= offRouteDistanceThreshold) {
-                            offRouteTimer?.invalidate()
-                            showOffRouteMessage()
-                        } else {
-                            if (offRouteTimer == nil) {
-                                offRouteTimer = Timer.scheduledTimer(timeInterval: offRouteTimeThreshold, target: self, selector: #selector(fireTimer), userInfo: nil, repeats: false)
-                            }
-                        }
-                    } else {
-                        if (offRouteTimer != nil) {
-                            offRouteTimer?.invalidate()
-                            offRouteTimer = nil
-                        }
-                    }
-                }
-            }
-        }
-    }
 }
 
 // MARK: - CLLocationManagerDelegate
-
 extension OffRouteViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
@@ -206,5 +104,159 @@ extension OffRouteViewController: CLLocationManagerDelegate {
             mapView.unregisterLocationManager()
             print("Not authorized to start PWLocationManager")
         }
+    }
+}
+
+// MARK: - TurnByTurnCollectionViewDelegate
+extension OffRouteViewController: TurnByTurnCollectionViewDelegate {
+    
+    func turnByTurnCollectionViewInstructionExpandTapped(_ collectionView: TurnByTurnCollectionView) {
+        let routeInstructionViewController = RouteInstructionListViewController()
+        routeInstructionViewController.configure(route: mapView.currentRoute)
+        routeInstructionViewController.presentFromViewController(self)
+    }
+}
+
+// MARK: - PWMapViewDelegate
+extension OffRouteViewController: PWMapViewDelegate {
+
+    func mapView(_ mapView: PWMapView!, locationManager: PWLocationManager!, didUpdateIndoorUserLocation userLocation: PWUserLocation!) {
+        if !firstLocationAcquired {
+            firstLocationAcquired = true
+            mapView.trackingMode = .follow
+
+            self.buildRoute()
+        } else {
+            if !modalVisible, !dontShowAgain, !isOffRouteAlertCooldownActive {
+                if let closestRouteInstruction = self.currentRoute?.closestInstructionTo(userLocation) {
+                    let distanceToRouteInstruction = MKMapPoint(userLocation.coordinate).distanceTo(closestRouteInstruction.polyline)
+                    
+                    if distanceToRouteInstruction > 0.0 {
+                        if (distanceToRouteInstruction >= offRouteDistanceThreshold) {
+                            offRouteTimer?.invalidate()
+                            showOffRouteMessage()
+                        } else if offRouteTimer == nil {
+                            offRouteTimer = Timer.scheduledTimer(timeInterval: offRouteTimeThreshold,
+                                                                 target: self,
+                                                                 selector: #selector(offRouteTimerExpired),
+                                                                 userInfo: nil,
+                                                                 repeats: false)
+
+                        }
+                    } else {
+                        offRouteTimer?.invalidate()
+                        offRouteTimer = nil
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - OffRouteModalViewControllerDelegate
+extension OffRouteViewController: OffRouteModalViewControllerDelegate {
+    func offRouteAlert(_ alert: OffRouteModalViewController, dismissedWithResult result: OffRouteModalViewController.Result) {
+        lastTimeOffRouteMessageWasDismissed = Date()
+        modalVisible = false
+        
+        switch result {
+        case .dismiss:
+            break
+            
+        case .reroute:
+            mapView.cancelRouting()
+            currentRoute = nil
+            buildRoute()
+            
+        case .dontShowAgain:
+            dontShowAgain = true
+        }
+    }
+}
+
+
+
+// MARK: - private
+private extension OffRouteViewController {
+    func startManagedLocationManager() {
+        DispatchQueue.main.async { [weak self] in
+            guard let buildingIdentifier = self?.buildingIdentifier else {
+                return
+            }
+            
+            let managedLocationManager = PWManagedLocationManager(buildingId: buildingIdentifier)
+            
+            self?.mapView.register(managedLocationManager)
+        }
+    }
+    
+    func configureMapViewConstraints() {
+        mapView.translatesAutoresizingMaskIntoConstraints = false
+        mapView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+    }
+    
+    func initializeTurnByTurn() {
+        mapView.setRouteManeuver(mapView.currentRoute.routeInstructions.first)
+        
+        if turnByTurnCollectionView == nil {
+            turnByTurnCollectionView = TurnByTurnCollectionView(mapView: mapView)
+            turnByTurnCollectionView?.turnByTurnDelegate = self
+            turnByTurnCollectionView?.configureInView(view)
+        }
+    }
+
+    func getDestinationPOI() -> PWPointOfInterest? {
+        if destinationPOIIdentifier != 0 {
+            return mapView.building.pois.first(where: { $0.identifier == destinationPOIIdentifier })
+        } else {
+            return mapView.building.pois.first
+        }
+    }
+    
+    func buildRoute() {
+        dontShowAgain = false
+
+        guard let destinationPOI = getDestinationPOI() else {
+            print("No points of interest found, please add at least one to the building in the Maas portal")
+            return
+        }
+
+        // Calculate a route and plot on the map
+        PWRoute.createRoute(from: mapView.indoorUserLocation, to: destinationPOI, options: nil, completion: { [weak self] (route, error) in
+            guard let self = self else {
+                return
+            }
+            
+            guard let route = route else {
+                print("Couldn't find a route from you current location to the destination.")
+                return
+            }
+        
+            self.currentRoute = route
+
+
+            let routeOptions = PWRouteUIOptions()
+            self.mapView.navigate(with: route, options: routeOptions)
+            
+            self.initializeTurnByTurn()
+        })
+    }
+
+    func showOffRouteMessage() {
+        guard modalVisible == false else {
+            return
+        }
+
+        modalVisible = true
+
+        let offRouteModal = OffRouteModalViewController()
+        offRouteModal.modalPresentationStyle = .overCurrentContext
+        offRouteModal.modalTransitionStyle = .crossDissolve
+        offRouteModal.delegate = self
+
+        present(offRouteModal, animated: true, completion: nil)
     }
 }

--- a/Samples/MapScenarios/MapScenarios/Scenarios/RoutingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/RoutingViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import PWCore
 import PWMapKit
 
+// MARK: - RoutingViewController
 class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -22,11 +23,11 @@ class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
     var buildingIdentifier = 0
     
     // Destination POI identifier for routing
-    var destinationPOIIdentifier: Int = 0
+    private var destinationPOIIdentifier: Int = 0
     
-    let mapView = PWMapView()
-    let locationManager = CLLocationManager()
-    var firstLocationAcquired = false
+    private let mapView = PWMapView()
+    private let locationManager = CLLocationManager()
+    private var firstLocationAcquired = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -90,9 +91,8 @@ class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
         mapView.trackingMode = .follow
         
         // Find the destination POI
-        let destinationPOI = mapView.building.pois.filter({
-            return $0.identifier == destinationPOIIdentifier
-        }).first
+        let destinationPOI = mapView.building.pois.first(where: { $0.identifier == destinationPOIIdentifier })
+        
         if destinationPOI == nil {
             warning("No points of interest found, please add at least one to the building in the Maas portal")
             return
@@ -123,7 +123,6 @@ class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
 }
 
 // MARK: - PWMapViewDelegate
-
 extension RoutingViewController: PWMapViewDelegate {
     
     func mapView(_ mapView: PWMapView!, locationManager: PWLocationManager!, didUpdateIndoorUserLocation userLocation: PWUserLocation!) {
@@ -135,7 +134,6 @@ extension RoutingViewController: PWMapViewDelegate {
 }
 
 // MARK: - CLLocationManagerDelegate
-
 extension RoutingViewController: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {

--- a/Samples/MapScenarios/MapScenarios/Scenarios/SearchPOIViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/SearchPOIViewController.swift
@@ -11,36 +11,7 @@ import UIKit
 import PWMapKit
 import PWCore
 
-class POITableViewCell: UITableViewCell {
-    
-    var poiImageView: UIImageView!
-    var titleLabel: UILabel!
-    
-    func configureSubviews() {
-        if poiImageView != nil && titleLabel != nil {
-            return
-        }
-        
-        poiImageView = UIImageView()
-        titleLabel = UILabel()
-        
-        poiImageView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(poiImageView)
-        poiImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10.0).isActive = true
-        poiImageView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
-        poiImageView.widthAnchor.constraint(equalToConstant: 32.0).isActive = true
-        poiImageView.heightAnchor.constraint(equalToConstant: 32.0).isActive = true
-        
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.numberOfLines = 0
-        addSubview(titleLabel)
-        titleLabel.leadingAnchor.constraint(equalTo: poiImageView.trailingAnchor, constant: 10.0).isActive = true
-        titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 5.0).isActive = true
-        titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 15.0).isActive = true
-        titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15.0).isActive = true
-    }
-}
-
+// MARK: - SearchPOIViewController
 class SearchPOIViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -48,16 +19,17 @@ class SearchPOIViewController: UIViewController, ScenarioSettingsProtocol {
     var accessKey = ""
     var signatureKey = ""
     
-    var buildingIdentifier = 0 // Enter your building identifier here, found on the building's Edit page on Maas portal
+    // Enter your building identifier here, found on the building's Edit page on Maas portal
+    var buildingIdentifier = 0
     
-    let mapView = PWMapView()
+    private let mapView = PWMapView()
     
     // Search view
-    let tableView = UITableView()
-    let poiCellReuseIdentifier = "POICell"
-    var sortedPointsOfInterest = [PWPointOfInterest]()
-    var filteredPointsOfInterest = [PWPointOfInterest]()
-    let searchController = UISearchController(searchResultsController: nil)
+    private let tableView = UITableView()
+    private let poiCellReuseIdentifier = "POICell"
+    private var sortedPointsOfInterest = [PWPointOfInterest]()
+    private var filteredPointsOfInterest = [PWPointOfInterest]()
+    private let searchController = UISearchController(searchResultsController: nil)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -132,7 +104,6 @@ class SearchPOIViewController: UIViewController, ScenarioSettingsProtocol {
 }
 
 // MARK: - UITableViewDataSource
-
 extension SearchPOIViewController: UITableViewDataSource {
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -155,7 +126,6 @@ extension SearchPOIViewController: UITableViewDataSource {
 }
 
 // MARK: - UITableViewDelegate
-
 extension SearchPOIViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -172,7 +142,6 @@ extension SearchPOIViewController: UITableViewDelegate {
 }
 
 // MARK: - UISearchResultsUpdating
-
 extension SearchPOIViewController: UISearchResultsUpdating {
     
     func updateSearchResults(for searchController: UISearchController) {
@@ -190,7 +159,6 @@ extension SearchPOIViewController: UISearchResultsUpdating {
 }
 
 // MARK: - UISearchBarDelegate
-
 extension SearchPOIViewController: UISearchBarDelegate {
     
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
@@ -203,7 +171,6 @@ extension SearchPOIViewController: UISearchBarDelegate {
 }
 
 // MARK: - Adjust for keyboard
-
 extension SearchPOIViewController {
     
     @objc func keyboardWillShow(notification: Notification) {
@@ -216,5 +183,36 @@ extension SearchPOIViewController {
     @objc func keyboardWillHide(notification: Notification) {
         tableView.contentInset = .zero
         tableView.scrollIndicatorInsets = .zero
+    }
+}
+
+// MARK: - POITableViewCell
+class POITableViewCell: UITableViewCell {
+    
+    var poiImageView: UIImageView!
+    var titleLabel: UILabel!
+    
+    func configureSubviews() {
+        if poiImageView != nil && titleLabel != nil {
+            return
+        }
+        
+        poiImageView = UIImageView()
+        titleLabel = UILabel()
+        
+        poiImageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(poiImageView)
+        poiImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10.0).isActive = true
+        poiImageView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        poiImageView.widthAnchor.constraint(equalToConstant: 32.0).isActive = true
+        poiImageView.heightAnchor.constraint(equalToConstant: 32.0).isActive = true
+        
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.numberOfLines = 0
+        addSubview(titleLabel)
+        titleLabel.leadingAnchor.constraint(equalTo: poiImageView.trailingAnchor, constant: 10.0).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 5.0).isActive = true
+        titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 15.0).isActive = true
+        titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15.0).isActive = true
     }
 }

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import PWCore
 import PWMapKit
 
+// MARK: - TurnByTurnLandmarksViewController
 class TurnByTurnLandmarksViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -22,8 +23,8 @@ class TurnByTurnLandmarksViewController: UIViewController, ScenarioSettingsProto
     var buildingIdentifier: Int = 0
     
     // Destination POI identifier for routing
-    var startPOIIdentifier: Int = 0
-    var destinationPOIIdentifier: Int = 0
+    private var startPOIIdentifier: Int = 0
+    private var destinationPOIIdentifier: Int = 0
     
     private let mapView = PWMapView()
     

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import PWCore
 import PWMapKit
 
+// MARK: - TurnByTurnViewController
 class TurnByTurnViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -21,8 +22,8 @@ class TurnByTurnViewController: UIViewController, ScenarioSettingsProtocol {
     var buildingIdentifier: Int = 0
     
     // Destination POI identifier for routing
-    var startPOIIdentifier: Int = 0
-    var destinationPOIIdentifier: Int = 0
+    private var startPOIIdentifier: Int = 0
+    private var destinationPOIIdentifier: Int = 0
     
     private let mapView = PWMapView()
     

--- a/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptButton.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptButton.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+// MARK: - VoicePromptButton
 class VoicePromptButton: UIView {
     
     var cornerRadius: CGFloat = 15 {

--- a/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptRouteViewController.swift
@@ -11,6 +11,7 @@ import PWCore
 import PWMapKit
 import UIKit
 
+// MARK: - VoicePromptRouteViewController
 class VoicePromptRouteViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -22,19 +23,19 @@ class VoicePromptRouteViewController: UIViewController, ScenarioSettingsProtocol
     var buildingIdentifier = 0
     
     // Replace with the destination POI identifier
-    let destinationPOIIdentifier = 0
+    private let destinationPOIIdentifier = 0
     
-    let mapView = PWMapView()
-    var turnByTurnCollectionView: TurnByTurnCollectionView?
-    let locationManager = CLLocationManager()
-    var firstLocationAcquired = false
-    let voicePromptButton = VoicePromptButton()
-    let voicePromptsLabel = UILabel()
-    var previouslyReadInstructions = Set<PWRouteInstruction>()
+    private let mapView = PWMapView()
+    private var turnByTurnCollectionView: TurnByTurnCollectionView?
+    private let locationManager = CLLocationManager()
+    private var firstLocationAcquired = false
+    private let voicePromptButton = VoicePromptButton()
+    private let voicePromptsLabel = UILabel()
+    private var previouslyReadInstructions = Set<PWRouteInstruction>()
     
     private let speechEnabledKey = "SpeechEnabled"
     
-    var speechEnabled: Bool {
+    private var speechEnabled: Bool {
         get {
             if UserDefaults.standard.value(forKey: speechEnabledKey) == nil {
                 return true
@@ -47,8 +48,8 @@ class VoicePromptRouteViewController: UIViewController, ScenarioSettingsProtocol
         }
     }
     
-    let speechSynthesizer = AVSpeechSynthesizer()
-    var instructionChangeCausedBySwipe = false
+    private let speechSynthesizer = AVSpeechSynthesizer()
+    private var instructionChangeCausedBySwipe = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -115,7 +116,6 @@ class VoicePromptRouteViewController: UIViewController, ScenarioSettingsProtocol
 }
 
 // MARK: - Voice Prompt UI
-
 extension VoicePromptRouteViewController {
     
     func configureVoiceUI() {
@@ -189,7 +189,6 @@ extension VoicePromptRouteViewController {
 }
 
 // MARK: - PWMapViewDelegate
-
 extension VoicePromptRouteViewController: PWMapViewDelegate {
 
     func mapView(_ mapView: PWMapView!, locationManager: PWLocationManager!, didUpdateIndoorUserLocation userLocation: PWUserLocation!) {
@@ -259,7 +258,6 @@ extension VoicePromptRouteViewController: TurnByTurnCollectionViewDelegate {
 }
 
 // MARK: - CLLocationManagerDelegate
-
 extension VoicePromptRouteViewController: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {

--- a/Samples/MapScenarios/MapScenarios/Scenarios/WalkTimeViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/WalkTimeViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import PWCore
 import PWMapKit
 
+// MARK: - WalkTimeViewController
 class WalkTimeViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
@@ -22,8 +23,8 @@ class WalkTimeViewController: UIViewController, ScenarioSettingsProtocol {
     var buildingIdentifier: Int = 0
     
     // Destination POI identifier for routing
-    var startPOIIdentifier: Int = 0
-    var destinationPOIIdentifier: Int = 0
+    private var startPOIIdentifier: Int = 0
+    private var destinationPOIIdentifier: Int = 0
     
     private let mapView = PWMapView()
     
@@ -42,7 +43,7 @@ class WalkTimeViewController: UIViewController, ScenarioSettingsProtocol {
     private var snappingLocation = false
     
     // Average speed
-    var averageSpeed: CLLocationSpeed {
+    private var averageSpeed: CLLocationSpeed {
         get {
             if speedSamples.count > 0 {
                 return speedSamples.reduce(0, +) / Double(speedSamples.count)
@@ -387,7 +388,7 @@ private extension WalkTimeViewController {
         })
     }
     
-    // called by super after route has been calculated
+    // called after route has been calculated
     func initializeTurnByTurn() {
         mapView.setRouteManeuver(mapView.currentRoute.routeInstructions.first)
         

--- a/Samples/MapScenarios/MapScenarios/Shared/WalkTimeView/WalkTimeView.swift
+++ b/Samples/MapScenarios/MapScenarios/Shared/WalkTimeView/WalkTimeView.swift
@@ -67,7 +67,6 @@ class WalkTimeView: UIView {
 }
 
 // MARK: - Helpers
-
 extension WalkTimeView {
     
     // Calculate the walk time


### PR DESCRIPTION
Apply the patch contained in [this zip file](https://github.com/phunware/maas-mapping-ios-sdk/files/3847672/qa_settings.patch.zip) on top of this branch, then run `pod update`, and build. Please ensure that the Off Route scenario displays Turn By Turn instruction cards for each maneuver. Also, please ensure that the Off Route alert still works as expected.

* Remove line breaks after MARK comments
* Change ‘var’ to ‘let’ for properties in view controllers that don’t need to be modified
* Move comment to be above “buildingIdenfier” properties instead of on same line
* Move POITableViewCell to bottom of file
* Move OffRouteViewController to appear above OffRouteModalViewController in project view
* Off route scenario no longer uses a timer for the alert cooldown. Instead we track the last time the alert was dismissed, and compare it when the location is updated to see if enough time has elapsed. This more closely matches the Android implementation.
* Add Turn By Turn instructions to Off Route scenario
* Comments and formatting