### PR TITLE
Feature/restore landmark routing

### DIFF
--- a/Samples/MapScenarios/LandmarkRouting.md
+++ b/Samples/MapScenarios/LandmarkRouting.md
@@ -1,4 +1,4 @@
-## Sample - Turn By Turn 
+## Sample - Turn By Turn with Landmarks
 
 This sample is configured almost the same as [TurnByTurnViewController.swift](./MapScenarios/Scenarios/TurnByTurnViewController.swift), except that it will utilize Landmark information in the route instructions, when available.
 

--- a/Samples/MapScenarios/LandmarkRouting.md
+++ b/Samples/MapScenarios/LandmarkRouting.md
@@ -1,0 +1,98 @@
+## Sample - Turn By Turn 
+
+### Overview
+- Display turn-by-turn route instruction card on top of map.
+- Swipe turn-by-turn card to select a route instruction.
+
+### Usage
+
+- Fill out `applicationId`, `accessKey`, `signatureKey`, `buildingIdentifier`, `startPOIIdentifier` and `destinationPOIIdentifier`.
+
+### Sample Code 
+- [TurnByTurnViewController.swift](./MapScenarios/Scenarios/TurnByTurnViewController.swift) - View controller
+- [TurnByTurnCollectionView.swift](./MapScenarios/Shared/TurnByTurnCollectionView/TurnByTurnCollectionView.swift) - Instruction collection view
+- [TurnByTurnInstructionCollectionViewCell.swift](./MapScenarios/Shared/TurnByTurnCollectionView/Cells/TurnByTurnInstructionCollectionViewCell.swift) - Instruction cell
+- [TurnByTurnInstructionCollectionViewCell.xib](./MapScenarios/Shared/TurnByTurnCollectionView/Cells/TurnByTurnInstructionCollectionViewCell.xib) - Instruction cell
+- [DirectionImages.xcassets](./MapScenarios/Shared/TurnByTurnCollectionView/Icons/DirectionImages.xcassets) - direction images
+
+**Step 1: Copy the following files to your project**
+
+- TurnByTurnCollectionView.swift
+- TurnByTurnInstructionCollectionViewCell.swift 
+- TurnByTurnInstructionCollectionViewCell.xib 
+- DirectionImages.xcassets 
+
+**Step 2: Present turn by turn view on the map whenever building and route are loaded**
+
+```
+func startRoute() {
+    // Set tracking mode to follow me
+    mapView.trackingMode = .follow
+    
+    // Find the destination POI
+    guard let startPOI = mapView.building.pois.first(where: { $0.identifier == startPOIIdentifier }),
+        let destinationPOI = mapView.building.pois.first(where: { $0.identifier == destinationPOIIdentifier }) else {
+        warning("Please put valid data for `startPOIIdentifier` and `destinationPOIIdentifier` in RoutingViewController.swift")
+        return
+    }
+    
+    // Calculate a route and plot on the map
+    PWRoute.createRoute(from: startPOI,
+                        to: destinationPOI,
+                        accessibility: false,
+                        excludedPoints: nil) { [weak self] (route, error) in
+        guard let route = route else {
+            self?.warning("Couldn't find a route between POI(\(self?.startPOIIdentifier ?? 0)) and POI(\(self?.destinationPOIIdentifier ?? 0)).")
+            return
+        }
+        
+        // Plot route on the map
+        let routeOptions = PWRouteUIOptions()
+        self?.mapView.navigate(with: route, options: routeOptions)
+        
+        // Initial route instructions
+        self?.initializeTurnByTurn()
+    }
+}
+
+func initializeTurnByTurn() {
+    mapView.setRouteManeuver(mapView.currentRoute.routeInstructions.first)
+    
+    if turnByTurnCollectionView == nil {
+        turnByTurnCollectionView = TurnByTurnCollectionView(mapView: mapView)
+        turnByTurnCollectionView?.turnByTurnDelegate = self
+        turnByTurnCollectionView?.configureInView(view)
+    }
+}
+```
+
+Because the view controller is a delegate of the `TurnByTurnCollectionView`, the collection view will ask the view controller for an `InstructionViewModel` to display for each instruction. The instruction view model is responsible for generating the turn by turn text that we display. We use the `BasicInstructionViewModel` to calculate this from the current instruction:
+```
+func turnByTurnCollectionView(_ collectionView: TurnByTurnCollectionView, viewModelFor routeInstruction: PWRouteInstruction) -> InstructionViewModel {
+    return BasicInstructionViewModel(for: routeInstruction)
+}
+```
+
+When the button to show the entire route list is displayed, show the route instruction list
+```
+func turnByTurnCollectionViewInstructionExpandTapped(_ collectionView: TurnByTurnCollectionView) {
+    let routeInstructionViewController = RouteInstructionListViewController()
+    routeInstructionViewController.delegate = self
+    routeInstructionViewController.configure(route: mapView.currentRoute)
+    routeInstructionViewController.presentFromViewController(self)
+}
+```
+
+The view controller is also a delegate of the `RouteInstructionListCollectionView`, which also needs an `InstructionViewModel` to generate the instruction text, similarly to the `TurnByTurnCollectionView`. We'll use `BasicInstructionViewModel` for this as well:
+```
+    func routeInstructionListViewController(_ viewController: RouteInstructionListViewController, viewModelFor routeInstruction: PWRouteInstruction)
+        -> InstructionViewModel {
+        return BasicInstructionViewModel(for: routeInstruction)
+    }
+```
+
+# Privacy
+You understand and consent to Phunware’s Privacy Policy located at www.phunware.com/privacy. If your use of Phunware’s software requires a Privacy Policy of your own, you also agree to include the terms of Phunware’s Privacy Policy in your Privacy Policy to your end users.
+
+# Terms
+Use of this software requires review and acceptance of our terms and conditions for developer use located at http://www.phunware.com/terms/

--- a/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
+++ b/Samples/MapScenarios/MapScenarios.xcodeproj/project.pbxproj
@@ -14,11 +14,13 @@
 		9A28B1E5235DFC5900215476 /* CLLocationDistance+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1E4235DFC5900215476 /* CLLocationDistance+Localization.swift */; };
 		9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */; };
 		9A5B6A1823748764007B41D4 /* InstructionTextOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5B6A1723748764007B41D4 /* InstructionTextOptions.swift */; };
-		9AA804942358BFC700B21924 /* FloorChangePOI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA804932358BFC700B21924 /* FloorChangePOI.swift */; };
+		9AA804942358BFC700B21924 /* PWFloorChangePOI+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA804932358BFC700B21924 /* PWFloorChangePOI+Extension.swift */; };
+		9AC881B023709B0900FCDEFC /* TurnByTurnLandmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC881AF23709B0900FCDEFC /* TurnByTurnLandmarksViewController.swift */; };
 		9ACB8953236A2FE3001F6F09 /* ScenarioSettingsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB8952236A2FE3001F6F09 /* ScenarioSettingsProtocol.swift */; };
 		9AFAAFD92363450800ED655C /* Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFAAFD22363450700ED655C /* Instruction.swift */; };
 		9AFAAFDA2363450800ED655C /* BasicInstructionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFAAFD32363450700ED655C /* BasicInstructionViewModel.swift */; };
 		9AFAAFDB2363450800ED655C /* InstructionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFAAFD42363450700ED655C /* InstructionViewModel.swift */; };
+		9AFAAFDC2363450800ED655C /* LandmarkInstructionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFAAFD52363450700ED655C /* LandmarkInstructionViewModel.swift */; };
 		9AFAAFDD2363450800ED655C /* ArrivedInstructionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFAAFD62363450700ED655C /* ArrivedInstructionViewModel.swift */; };
 		9AFAAFDE2363450800ED655C /* UIImage+Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFAAFD72363450700ED655C /* UIImage+Instruction.swift */; };
 		9D1ECD2A2225DE0C0029A667 /* BluedotLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1ECD292225DE0C0029A667 /* BluedotLocationViewController.swift */; };
@@ -62,11 +64,13 @@
 		9A28B1E4235DFC5900215476 /* CLLocationDistance+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationDistance+Localization.swift"; sourceTree = "<group>"; };
 		9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
 		9A5B6A1723748764007B41D4 /* InstructionTextOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionTextOptions.swift; sourceTree = "<group>"; };
-		9AA804932358BFC700B21924 /* FloorChangePOI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorChangePOI.swift; sourceTree = "<group>"; };
+		9AA804932358BFC700B21924 /* PWFloorChangePOI+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PWFloorChangePOI+Extension.swift"; sourceTree = "<group>"; };
+		9AC881AF23709B0900FCDEFC /* TurnByTurnLandmarksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnByTurnLandmarksViewController.swift; sourceTree = "<group>"; };
 		9ACB8952236A2FE3001F6F09 /* ScenarioSettingsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScenarioSettingsProtocol.swift; sourceTree = "<group>"; };
 		9AFAAFD22363450700ED655C /* Instruction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Instruction.swift; sourceTree = "<group>"; };
 		9AFAAFD32363450700ED655C /* BasicInstructionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicInstructionViewModel.swift; sourceTree = "<group>"; };
 		9AFAAFD42363450700ED655C /* InstructionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionViewModel.swift; sourceTree = "<group>"; };
+		9AFAAFD52363450700ED655C /* LandmarkInstructionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LandmarkInstructionViewModel.swift; sourceTree = "<group>"; };
 		9AFAAFD62363450700ED655C /* ArrivedInstructionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrivedInstructionViewModel.swift; sourceTree = "<group>"; };
 		9AFAAFD72363450700ED655C /* UIImage+Instruction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Instruction.swift"; sourceTree = "<group>"; };
 		9CB47B3A056D6CD629EBD3CA /* Pods-MapScenarios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapScenarios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapScenarios/Pods-MapScenarios.debug.xcconfig"; sourceTree = "<group>"; };
@@ -181,8 +185,8 @@
 				9A5B6A1723748764007B41D4 /* InstructionTextOptions.swift */,
 				9AFAAFD42363450700ED655C /* InstructionViewModel.swift */,
 				9AFAAFD32363450700ED655C /* BasicInstructionViewModel.swift */,
+				9AFAAFD52363450700ED655C /* LandmarkInstructionViewModel.swift */,
 				9AFAAFD62363450700ED655C /* ArrivedInstructionViewModel.swift */,
-				9AA804932358BFC700B21924 /* FloorChangePOI.swift */,
 			);
 			path = Instruction;
 			sourceTree = "<group>";
@@ -196,6 +200,7 @@
 				E378581E22145F4F0059A179 /* PWMapView+Helper.swift */,
 				E378581C221313500059A179 /* PWRoute+Helper.swift */,
 				E378583B222821B10059A179 /* UIColor+Helper.swift */,
+				9AA804932358BFC700B21924 /* PWFloorChangePOI+Extension.swift */,
 				9A28B1EC235E0C2600215476 /* NSMutableAttributedString+Extension.swift */,
 			);
 			name = Extensions;
@@ -285,6 +290,7 @@
 				E3C771C92050555D00780D0F /* RoutingViewController.swift */,
 				E3C771CE2050846E00780D0F /* SearchPOIViewController.swift */,
 				9D93FCE12208A2F000A2EB02 /* TurnByTurnViewController.swift */,
+				9AC881AF23709B0900FCDEFC /* TurnByTurnLandmarksViewController.swift */,
 				9D1ECD2B2225DE1C0029A667 /* WalkTimeViewController.swift */,
 				7E87A2F0222478DC004ABFE9 /* OffRoute */,
 				E37858222217062D0059A179 /* Voice Prompt */,
@@ -375,7 +381,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MapScenarios/Pods-MapScenarios-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-MapScenarios/Pods-MapScenarios-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${PODS_ROOT}/MistSDK/Framework/MistSDK.framework",
 				"${PODS_ROOT}/PWCore/Framework/PWCore.framework",
@@ -396,7 +402,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MapScenarios/Pods-MapScenarios-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapScenarios/Pods-MapScenarios-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9C0D9C77708739E790BD23D7 /* [CP] Check Pods Manifest.lock */ = {
@@ -432,7 +438,7 @@
 				E3785831222073DC0059A179 /* TurnByTurnCollectionView.swift in Sources */,
 				E378581D221313500059A179 /* PWRoute+Helper.swift in Sources */,
 				7EFF9C602232FCD3002BDD0A /* OffRouteModalViewController.swift in Sources */,
-				9AA804942358BFC700B21924 /* FloorChangePOI.swift in Sources */,
+				9AA804942358BFC700B21924 /* PWFloorChangePOI+Extension.swift in Sources */,
 				9AFAAFD92363450800ED655C /* Instruction.swift in Sources */,
 				9A28B1E5235DFC5900215476 /* CLLocationDistance+Localization.swift in Sources */,
 				9A5B6A1823748764007B41D4 /* InstructionTextOptions.swift in Sources */,
@@ -444,7 +450,9 @@
 				E3C3799E204D90AA00905731 /* ScenarioSelectViewController.swift in Sources */,
 				9AFAAFDD2363450800ED655C /* ArrivedInstructionViewModel.swift in Sources */,
 				9D1ECD2C2225DE1C0029A667 /* WalkTimeViewController.swift in Sources */,
+				9AC881B023709B0900FCDEFC /* TurnByTurnLandmarksViewController.swift in Sources */,
 				E3C3799C204D90AA00905731 /* AppDelegate.swift in Sources */,
+				9AFAAFDC2363450800ED655C /* LandmarkInstructionViewModel.swift in Sources */,
 				9A28B1ED235E0C2600215476 /* NSMutableAttributedString+Extension.swift in Sources */,
 				E378582E222073CA0059A179 /* TurnByTurnInstructionCollectionViewCell.swift in Sources */,
 				E3C771CF2050846E00780D0F /* SearchPOIViewController.swift in Sources */,

--- a/Samples/MapScenarios/MapScenarios/Base.lproj/Main.storyboard
+++ b/Samples/MapScenarios/MapScenarios/Base.lproj/Main.storyboard
@@ -235,8 +235,35 @@
                                             <segue destination="Ara-X3-Rg3" kind="show" identifier="TurnByTurnViewController" id="vww-2O-fHJ"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="WalkTimeCell" textLabel="jye-p8-lN5" detailTextLabel="tfa-R7-Xlj" style="IBUITableViewCellStyleSubtitle" id="c4u-Ua-BQZ" userLabel="WalkTimeCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TurnByTurnCell" textLabel="zMX-bF-hs6" detailTextLabel="2gk-N7-U1k" style="IBUITableViewCellStyleSubtitle" id="G5J-ss-9Pt" userLabel="TurnByTurnLandmarksCell">
                                         <rect key="frame" x="0.0" y="380" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="G5J-ss-9Pt" id="i1v-Gl-zBV">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Route - Turn By Turn with Landmarks" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zMX-bF-hs6">
+                                                    <rect key="frame" x="16" y="5" width="284" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Show turn-by-turn navigation with landmarks, if available" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2gk-N7-U1k">
+                                                    <rect key="frame" x="16" y="25.5" width="322.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="EeK-CA-Ubh" kind="show" id="UHA-80-xLI"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="WalkTimeCell" textLabel="jye-p8-lN5" detailTextLabel="tfa-R7-Xlj" style="IBUITableViewCellStyleSubtitle" id="c4u-Ua-BQZ" userLabel="WalkTimeCell">
+                                        <rect key="frame" x="0.0" y="424" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c4u-Ua-BQZ" id="nVC-kl-z7M">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -263,7 +290,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="LocationSharingCell" textLabel="yA8-81-sfn" detailTextLabel="Pey-Ej-1CD" style="IBUITableViewCellStyleSubtitle" id="SYq-xN-N3x" userLabel="VoicedRouteCell">
-                                        <rect key="frame" x="0.0" y="424" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="468" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SYq-xN-N3x" id="fuH-rc-4ys">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -290,7 +317,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="OffRouteCell" textLabel="Gqe-VH-29Q" detailTextLabel="6jp-6k-zm1" style="IBUITableViewCellStyleSubtitle" id="ejc-qn-oNj">
-                                        <rect key="frame" x="0.0" y="468" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="512" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ejc-qn-oNj" id="Cge-z2-YZg">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -535,6 +562,22 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Dlq-7a-nUe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-223" y="-348"/>
+        </scene>
+        <!--Turn By Turn Landmarks View Controller-->
+        <scene sceneID="zSe-8r-gy1">
+            <objects>
+                <viewController id="EeK-CA-Ubh" customClass="TurnByTurnLandmarksViewController" customModule="MapScenarios" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="UPv-eK-q9x">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="FMW-Sv-XXK"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="qVs-6T-af4"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="gEu-dd-7ry" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2140" y="3045"/>
         </scene>
     </scenes>
 </document>

--- a/Samples/MapScenarios/MapScenarios/Extensions/PWFloorChangePOI+Extension.swift
+++ b/Samples/MapScenarios/MapScenarios/Extensions/PWFloorChangePOI+Extension.swift
@@ -1,5 +1,5 @@
 //
-//  FloorChangePOI.swift
+//  PWFloorChangePOI+Extension.swift
 //  MapScenarios
 //
 //  Created by Aaron Pendley on 10/17/19.
@@ -9,17 +9,22 @@
 import Foundation
 import PWMapKit
 
-enum FloorChangePOI: Int {
-    case stairs = 20001
-    case elevator = 20000
-    case escalator = 20003
-
+extension PWFloorChangePOI {
     init?(mapPoint: PWMapPoint) {
         // only PWPointOfInterest objects have a 'pointOfInterestType' property
         guard let poi = mapPoint as? PWPointOfInterest, let poiType = poi.pointOfInterestType else {
             return nil
         }
         
-        self.init(rawValue: poiType.identifier)
+        switch poiType.identifier {
+        case PWFloorChangePOI.stairs.rawValue:
+            self = .stairs
+        case PWFloorChangePOI.elevator.rawValue:
+            self = .elevator
+        case PWFloorChangePOI.escalator.rawValue:
+            self = .escalator
+        default:
+            return nil
+        }
     }
 }

--- a/Samples/MapScenarios/MapScenarios/Extensions/PWMapView+Helper.swift
+++ b/Samples/MapScenarios/MapScenarios/Extensions/PWMapView+Helper.swift
@@ -23,7 +23,7 @@ extension PWMapView {
         var numberOfFloorSwitchInstructions = 0.0 // Add distance to account for floor switch time
         for i in instructionIndex..<route.routeInstructions.count {
             let instruction = route.routeInstructions[i]
-            if instruction.movementDirection.isFloorChange {
+            if instruction.direction == .floorChange {
                 numberOfFloorSwitchInstructions += 1.0
             } else {
                 distanceTotal = distanceTotal + instruction.distance

--- a/Samples/MapScenarios/MapScenarios/Instruction/LandmarkInstructionViewModel.swift
+++ b/Samples/MapScenarios/MapScenarios/Instruction/LandmarkInstructionViewModel.swift
@@ -1,0 +1,247 @@
+//
+//  LandmarkInstructionViewModel.swift
+//  MapScenarios
+//
+//  Created by Aaron Pendley on 10/18/19.
+//  Copyright © 2019 Phunware. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import PWMapKit
+
+// MARK: - Notes
+// LandmarkInstructionViewModel contains presentation logic for route instructions generated using the
+// landmark routing feature. Straight/Turn instructions may contain one or more landmarks (though we're usually
+// only interested in the last one). If a landmark is found, we can provide more detailed instructions
+// (such as "Turn right in 10 feet at the Water Cooler"). If no landmark is found, we fall back to basic
+// instruction text.
+
+// MARK: - LandmarkInstructionViewModel
+struct LandmarkInstructionViewModel {
+    private let instruction: Instruction
+    private let standardOptions: InstructionTextOptions
+    private let highlightOptions: InstructionTextOptions
+    
+    init(for routeInstruction: PWRouteInstruction,
+         standardOptions: InstructionTextOptions = .defaultStandardOptions,
+         highlightOptions: InstructionTextOptions = .defaultHighlightOptions) {
+        self.instruction = Instruction(for: routeInstruction)
+        self.standardOptions = standardOptions
+        self.highlightOptions = highlightOptions
+    }
+}
+
+// MARK: InstructionViewModel conformance
+extension LandmarkInstructionViewModel: InstructionViewModel {
+    var image: UIImage {
+        return .image(for: instruction)
+    }
+    
+    var attributedText: NSAttributedString {
+        let straightString = NSLocalizedString("Continue straight", comment: "")
+        
+        switch instruction.instructionType {
+        case .straight:
+            if let landmark = instruction.routeInstruction.landmarks?.last {
+                let templateString = NSLocalizedString("$0 for $1 towards $2", comment: "$0 = Continue straight, $1 = distance, $2 = landmark")
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                attributed.replace(substring: "$0", with: straightString, attributes: highlightOptions.attributes)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                attributed.replace(substring: "$2", with: landmark.name, attributes: highlightOptions.attributes)
+                
+                return attributed
+            } else {
+                let templateString = NSLocalizedString("$0 for $1", comment: "$0 = Continue straight, $1 = distance")
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                attributed.replace(substring: "$0", with: straightString, attributes: highlightOptions.attributes)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                
+                return attributed
+            }
+            
+        case .turn(let direction):
+            if let landmark = instruction.routeInstruction.landmarks?.last {
+                let templateString = NSLocalizedString("$0 in $1 $2 $3", comment: "$0 = direction, $1 = distance, $2 = at/after, $3 = landmark name")
+                
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                let turnString = string(forTurn: direction) ?? ""
+                attributed.replace(substring: "$0", with: turnString, attributes: highlightOptions.attributes)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                
+                let positionString = (landmark.position == .at)
+                    ? NSLocalizedString("at", comment: "")
+                    : NSLocalizedString("after", comment: "")
+                
+                attributed.replace(substring: "$2", with: positionString, attributes: standardOptions.attributes)
+                attributed.replace(substring: "$3", with: landmark.name, attributes: highlightOptions.attributes)
+                
+                return attributed
+                
+            } else {
+                let templateString = NSLocalizedString("$0 in $1", comment: "$0 = direction, $1 = distance")
+                let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+                
+                let turnString = string(forTurn: direction) ?? ""
+                attributed.replace(substring: "$0", with: turnString, attributes: highlightOptions.attributes)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+                
+                return attributed
+            }
+            
+        case .upcomingFloorChange(let floorChange):
+            let templateString = NSLocalizedString("$0 $1 towards $2 to $3", comment: "$0 = Continue straight, $1 = distance, $2 floor change type, $3 = floor name")
+            let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+            
+            attributed.replace(substring: "$0", with: straightString, attributes: highlightOptions.attributes)
+            
+            let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+            attributed.replace(substring: "$1", with: distanceString, attributes: standardOptions.attributes)
+            
+            let floorChangeTypeString = string(for: floorChange.floorChangeType)
+            attributed.replace(substring: "$2", with: floorChangeTypeString, attributes: highlightOptions.attributes)
+            attributed.replace(substring: "$3", with: floorChange.floorName, attributes: highlightOptions.attributes)
+            
+            return attributed
+            
+        case .floorChange(let floorChange):
+            let templateString = (floorChange.floorChangeDirection == .sameFloor)
+                ? NSLocalizedString("Take the $0 to $2", comment: "$0 = floor change type, $2 = floor name")
+                : NSLocalizedString("Take the $0 $1 to $2", comment: "$0 = floor change type, $1 = floor change direction, $2 = floor name")
+            
+            let attributed = NSMutableAttributedString(string: templateString, attributes: standardOptions.attributes)
+            
+            let floorChangeTypeString = string(for: floorChange.floorChangeType)
+            attributed.replace(substring: "$0", with: floorChangeTypeString, attributes: highlightOptions.attributes)
+            
+            let directionString = string(forFloorChangeDirection: floorChange.floorChangeDirection) ?? ""
+            attributed.replace(substring: "$1", with: directionString, attributes: standardOptions.attributes)
+            attributed.replace(substring: "$2", with: floorChange.floorName, attributes: highlightOptions.attributes)
+            
+            return attributed
+        }
+    }
+    
+    var voicePrompt: String {
+        var prompt = baseStringForVoicePrompt
+        
+        // For the last directions, append a string indicating arrival.
+        if instruction.isLast {
+            let arrivalString = " " + NSLocalizedString("to arrive at your destination", comment: "")
+            prompt = prompt + arrivalString
+        }
+        
+        return prompt
+    }
+}
+
+// MARK: - private
+private extension LandmarkInstructionViewModel {
+    var baseStringForVoicePrompt: String {
+        let straightString = NSLocalizedString("Continue straight", comment: "")
+        
+        switch instruction.instructionType {
+        case .straight:
+            if let landmark = instruction.routeInstruction.landmarks?.last {
+                let templateString = NSLocalizedString("$0 for $1 towards $2", comment: "$0 = Continue straight, $1 = distance, $2 = landmark")
+                var prompt = templateString
+                
+                prompt = prompt.replacingOccurrences(of: "$0", with: straightString)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                prompt = prompt.replacingOccurrences(of: "$1", with: distanceString)
+                prompt = prompt.replacingOccurrences(of: "$2", with: landmark.name)
+                
+                return prompt
+            } else {
+                let templateString = NSLocalizedString("$0 for $1", comment: "$0 = Continue straight, $1 = distance")
+                var prompt = templateString
+                
+                prompt = prompt.replacingOccurrences(of: "$0", with: straightString)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                prompt = prompt.replacingOccurrences(of: "$1", with: distanceString)
+                
+                return prompt
+            }
+            
+        case .turn(let direction):
+            if let landmark = instruction.routeInstruction.landmarks?.last {
+                let templateString = NSLocalizedString("$0 for $1, then $2 $3 $4", comment: "$0 = Continue straight, $1 = distance, $2 = direction, $3 = at/after, $4 = landmark name")
+                var prompt = templateString
+                
+                prompt = prompt.replacingOccurrences(of: "$0", with: straightString)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                prompt = prompt.replacingOccurrences(of: "$1", with: distanceString)
+                
+                let turnString = string(forTurn: direction)?.lowercased() ?? ""
+                prompt = prompt.replacingOccurrences(of: "$2", with: turnString)
+                
+                let positionString = (landmark.position == .at)
+                    ? NSLocalizedString("at", comment: "")
+                    : NSLocalizedString("after", comment: "")
+                
+                prompt = prompt.replacingOccurrences(of: "$3", with: positionString)
+                prompt = prompt.replacingOccurrences(of: "$4", with: landmark.name)
+                
+                return prompt
+            } else {
+                let templateString = NSLocalizedString("$0 for $1, then $2", comment: "$0 = Continue straight, $1 = distance, $2 = direction")
+                var prompt = templateString
+                
+                prompt = prompt.replacingOccurrences(of: "$0", with: straightString)
+                
+                let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+                prompt = prompt.replacingOccurrences(of: "$1", with: distanceString)
+                
+                let turnString = string(forTurn: direction)?.lowercased() ?? ""
+                prompt = prompt.replacingOccurrences(of: "$2", with: turnString)
+                
+                return prompt
+            }
+            
+        case .upcomingFloorChange(let floorChange):
+            let templateString = NSLocalizedString("$0 $1 towards $2 to $3", comment: "$0 = Continue straight, $1 = distance, $2 floor change type, $3 = floor name")
+            var prompt = templateString
+            
+            prompt = prompt.replacingOccurrences(of: "$0", with: straightString)
+            
+            let distanceString = instruction.routeInstruction.distance.localizedDistanceInSmallUnits
+            prompt = prompt.replacingOccurrences(of: "$1", with: distanceString)
+            
+            let floorChangeTypeString = string(for: floorChange.floorChangeType)
+            prompt = prompt.replacingOccurrences(of: "$2", with: floorChangeTypeString)
+            prompt = prompt.replacingOccurrences(of: "$3", with: floorChange.floorName)
+            
+            return prompt
+            
+        case .floorChange(let floorChange):
+            let templateString = (floorChange.floorChangeDirection == .sameFloor)
+                ? NSLocalizedString("Take the $0 to $2", comment: "$0 = floor change type, $2 = floor name")
+                : NSLocalizedString("Take the $0 $1 to $2", comment: "$0 = floor change type, $1 = floor change direction, $2 = floor name")
+            
+            var prompt = templateString
+            
+            let floorChangeTypeString = string(for: floorChange.floorChangeType)
+            prompt = prompt.replacingOccurrences(of: "$0", with: floorChangeTypeString)
+            
+            let directionString = string(forFloorChangeDirection: floorChange.floorChangeDirection) ?? ""
+            prompt = prompt.replacingOccurrences(of: "$1", with: directionString)
+            prompt = prompt.replacingOccurrences(of: "$2", with: floorChange.floorName)
+            
+            return prompt
+        }
+    }
+}

--- a/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
@@ -229,10 +229,7 @@ private extension OffRouteViewController {
         }
 
         // Calculate a route and plot on the map
-        PWRoute.createRoute(from: mapView.indoorUserLocation,
-                            to: destinationPOI,
-                            accessibility: false,
-                            excludedPoints: nil) { [weak self] (route, error) in
+        PWRoute.createRoute(from: mapView.indoorUserLocation, to: destinationPOI, options: nil, completion: { [weak self] (route, error) in
             guard let self = self else {
                 return
             }
@@ -249,7 +246,7 @@ private extension OffRouteViewController {
             self.mapView.navigate(with: route, options: routeOptions)
             
             self.initializeTurnByTurn()
-        }
+        })
     }
 
     func showOffRouteMessage() {

--- a/Samples/MapScenarios/MapScenarios/Scenarios/RoutingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/RoutingViewController.swift
@@ -101,8 +101,8 @@ class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
         // Calculate a route and plot on the map
         PWRoute.createRoute(from: mapView.indoorUserLocation,
                             to: destinationPOI,
-                            accessibility: false,
-                            excludedPoints: nil) { [weak self] (route, error) in
+                            options: nil,
+                            completion: { [weak self] (route, error) in
             guard let route = route else {
                 self?.warning("Couldn't find a route from you current location to the destination.")
                 return
@@ -118,7 +118,7 @@ class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
             // routeOptions.joinPointColor = <#joinPointColor#>
             // routeOptions.lineJoin = <#.miter, round or bevel#>
             self?.mapView.navigate(with: route, options: routeOptions)
-        }
+        })
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
@@ -1,8 +1,9 @@
 //
-//  TurnByTurnViewController.swift
+//  TurnByTurnLandmarksViewController.swift
 //  MapScenarios
 //
-//  Copyright © 2018 Phunware. All rights reserved.
+//  Created by Aaron Pendley on 11/4/19.
+//  Copyright © 2019 Phunware. All rights reserved.
 //
 
 import Foundation
@@ -10,8 +11,8 @@ import UIKit
 import PWCore
 import PWMapKit
 
-// MARK: - TurnByTurnViewController
-class TurnByTurnViewController: UIViewController, ScenarioSettingsProtocol {
+// MARK: - TurnByTurnLandmarksViewController
+class TurnByTurnLandmarksViewController: UIViewController, ScenarioSettingsProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -73,9 +74,11 @@ class TurnByTurnViewController: UIViewController, ScenarioSettingsProtocol {
 }
 
 // MARK: - TurnByTurnCollectionViewDelegate
-extension TurnByTurnViewController: TurnByTurnCollectionViewDelegate {
+extension TurnByTurnLandmarksViewController: TurnByTurnCollectionViewDelegate {
     func turnByTurnCollectionView(_ collectionView: TurnByTurnCollectionView, viewModelFor routeInstruction: PWRouteInstruction) -> InstructionViewModel {
-        return BasicInstructionViewModel(for: routeInstruction)
+        // We'll use the LandmarkInstructionViewModel to generate the view model for our collection view cells,
+        // which will use the landmarks generated along with the route to augment the instruction text.
+        return LandmarkInstructionViewModel(for: routeInstruction)
     }
     
     func turnByTurnCollectionViewInstructionExpandTapped(_ collectionView: TurnByTurnCollectionView) {
@@ -87,15 +90,15 @@ extension TurnByTurnViewController: TurnByTurnCollectionViewDelegate {
 }
 
 // MARK: - RouteInstructionListViewControllerDelegate
-extension TurnByTurnViewController: RouteInstructionListViewControllerDelegate {
+extension TurnByTurnLandmarksViewController: RouteInstructionListViewControllerDelegate {
     func routeInstructionListViewController(_ viewController: RouteInstructionListViewController, viewModelFor routeInstruction: PWRouteInstruction)
         -> InstructionViewModel {
-        return BasicInstructionViewModel(for: routeInstruction)
+        return LandmarkInstructionViewModel(for: routeInstruction)
     }
 }
 
 // MARK: - private
-private extension TurnByTurnViewController {
+private extension TurnByTurnLandmarksViewController {
     func configureMapViewConstraints() {
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
@@ -115,11 +118,12 @@ private extension TurnByTurnViewController {
             return
         }
         
+        // Create a PWRouteOptions object with landmarksEnabled set to true so landmarks will be injected into route info (if available)
         let routeOptions = PWRouteOptions(accessibilityEnabled: false,
                                           landmarksEnabled: true,
                                           excludedPointIdentifiers: nil)
         
-        // Calculate a route and plot on the map
+        // Calculate a route and plot on the map with our specified route options
         PWRoute.createRoute(from: startPOI,
                             to: destinationPOI,
                             options: routeOptions,
@@ -130,8 +134,8 @@ private extension TurnByTurnViewController {
             }
             
             // Plot route on the map
-            let routeOptions = PWRouteUIOptions()
-            self?.mapView.navigate(with: route, options: routeOptions)
+            let uiOptions = PWRouteUIOptions()
+            self?.mapView.navigate(with: route, options: uiOptions)
             
             // Initial route instructions
             self?.initializeTurnByTurn()

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
@@ -33,7 +33,7 @@ class TurnByTurnLandmarksViewController: UIViewController, ScenarioSettingsProto
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        navigationItem.title = "Route - Turn By Turn"
+        navigationItem.title = "Route - Turn By Turn with Landmarks"
         
         if !validateScenarioSettings() {
             return

--- a/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptRouteViewController.swift
@@ -199,11 +199,10 @@ extension VoicePromptRouteViewController: PWMapViewDelegate {
                 return
             }
             
-            
             PWRoute.createRoute(from: mapView.indoorUserLocation,
                                 to: destinationPOI,
-                                accessibility: false,
-                                excludedPoints: nil) { [weak self] (route, error) in
+                                options: nil,
+                                completion: { [weak self] (route, error) in
                 guard let route = route else {
                     print("Couldn't find a route from you current location to the destination.")
                     return
@@ -212,7 +211,7 @@ extension VoicePromptRouteViewController: PWMapViewDelegate {
                 mapView.navigate(with: route)
                 self?.initializeTurnByTurn()
                 self?.configureVoiceUI()
-            }
+            })
         }
     }
     

--- a/Samples/MapScenarios/MapScenarios/Scenarios/WalkTimeViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/WalkTimeViewController.swift
@@ -372,8 +372,8 @@ private extension WalkTimeViewController {
         // Calculate a route and plot on the map
         PWRoute.createRoute(from: startPOI,
                             to: destinationPOI,
-                            accessibility: false,
-                            excludedPoints: nil) { [weak self] (route, error) in
+                            options: nil,
+                            completion: { [weak self] (route, error) in
             guard let route = route else {
                 self?.warning("Couldn't find a route between POI(\(self?.startPOIIdentifier ?? 0)) and POI(\(self?.destinationPOIIdentifier ?? 0)).")
                 return
@@ -385,7 +385,7 @@ private extension WalkTimeViewController {
             
             // Initial route instructions
             self?.initializeTurnByTurn()
-        }
+        })
     }
     
     // called after route has been calculated

--- a/Samples/MapScenarios/WalkTime.md
+++ b/Samples/MapScenarios/WalkTime.md
@@ -55,7 +55,7 @@ func mapView(_ mapView: PWMapView!, didChange instruction: PWRouteInstruction!) 
 }
 ```
 
-**Step 4: `updateWalkTime()` calculates the time and updates the view **
+**Step 4: `updateWalkTime()` calculates the time and updates the view**
 If a blue dot has been acquired, we calculate the time from the current blue dot position. Otherwise, we calculate from the beginning of the current maneuver. When we get close enough to our destination, we remove the walk time view.
 ```
 func updateWalkTime() {

--- a/Samples/MapScenarios/WalkTime.md
+++ b/Samples/MapScenarios/WalkTime.md
@@ -55,7 +55,7 @@ func mapView(_ mapView: PWMapView!, didChange instruction: PWRouteInstruction!) 
 }
 ```
 
-**Step 4: `updateWalkTime()` calculates the time and updates the view`**
+**Step 4: `updateWalkTime()` calculates the time and updates the view **
 If a blue dot has been acquired, we calculate the time from the current blue dot position. Otherwise, we calculate from the beginning of the current maneuver. When we get close enough to our destination, we remove the walk time view.
 ```
 func updateWalkTime() {

--- a/Samples/MapScenarios/WalkTime.md
+++ b/Samples/MapScenarios/WalkTime.md
@@ -56,6 +56,7 @@ func mapView(_ mapView: PWMapView!, didChange instruction: PWRouteInstruction!) 
 ```
 
 **Step 4: `updateWalkTime()` calculates the time and updates the view**
+
 If a blue dot has been acquired, we calculate the time from the current blue dot position. Otherwise, we calculate from the beginning of the current maneuver. When we get close enough to our destination, we remove the walk time view.
 ```
 func updateWalkTime() {

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -17,7 +17,7 @@ PWMapKit Samples for iOS
 ## MapScenarios
 
 ### Overview
-- A couple of different use cases in both Swift and Objective C.
+- A couple of different use cases in Swift.
 - Each use case has a ViewController.
 
 ### LoadBuildingViewController
@@ -191,13 +191,21 @@ mapView.selectAnnotation(pointOfInterest, animated: true)
 
 ##### [Sample code](./MapScenarios/LocationSharing.md)
 
-### TurnByTurnCollectionView
+### TurnByTurnViewController
 - Show route instructions in carousel UI
 
 ##### Usage:
 - Fill out `applicationId`, `accessKey`, `signatureKey`, and `buildingIdentifier`
 
 ##### [Sample code](./MapScenarios/TurnByTurn.md)
+
+### TurnByTurnLandmarksViewController
+- Show route instructions (using landmarks) in carousel UI
+
+##### Usage:
+- Fill out `applicationId`, `accessKey`, `signatureKey`, and `buildingIdentifier`
+
+##### [Sample code](./MapScenarios/LandmarkRouting.md)
 
 ### VoicePromptRouteViewController
 - Read route instructions out loud


### PR DESCRIPTION

Changes:
-
* Revert commit that retrofitted the samples for the previous version of the Mapkit SDK.
* Add markdown file to explain Landmark Routing sample.
* Added link to landmark routing markdown file to main scenario explanation
* Fixed some typos in some documentation

To test:
- 
Make sure your local Mapkit working copy is pointed at the latest `dev` branch.
Apply the patch in [this zip file](https://github.com/phunware/maas-mapping-ios-sdk/files/3922959/qa_setup_12_4.patch.zip) on top of this branch to configure building and route POIs (you may need to update the local path to your mapkit installation), then run `pod update` before building. Please ensure that landmark info is displayed in the Turn by Turn - Landmarks sample.