### PR TITLE
SWMAAS-1737 - add azul error reporting to scenarios

### DIFF
--- a/Samples/MapScenarios/MapScenarios/ScenarioSelectViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/ScenarioSelectViewController.swift
@@ -33,7 +33,7 @@ class ScenarioSelectViewController: UITableViewController {
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if var scenarioController = segue.destination as? ScenarioSettingsProtocol {
+        if var scenarioController = segue.destination as? ScenarioProtocol {
             if scenarioController.applicationId.isEmpty {
                 scenarioController.applicationId = universalApplicationId
             }

--- a/Samples/MapScenarios/MapScenarios/ScenarioSettingsProtocol.swift
+++ b/Samples/MapScenarios/MapScenarios/ScenarioSettingsProtocol.swift
@@ -34,6 +34,8 @@ extension ScenarioProtocol where Self: UIViewController {
         let alertController = UIAlertController(title: title, message: failureMessage, preferredStyle: .alert)
         let okayAction = UIAlertAction(title: "Okay", style: .default, handler: nil)
         alertController.addAction(okayAction)
-        present(alertController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
 }

--- a/Samples/MapScenarios/MapScenarios/ScenarioSettingsProtocol.swift
+++ b/Samples/MapScenarios/MapScenarios/ScenarioSettingsProtocol.swift
@@ -8,15 +8,16 @@
 
 import Foundation
 import UIKit
+import PWMapKit
 
-protocol ScenarioSettingsProtocol {
+protocol ScenarioProtocol {
     var applicationId: String { get set }
     var accessKey: String { get set }
     var signatureKey: String { get set }
     var buildingIdentifier: Int { get set }
 }
 
-extension ScenarioSettingsProtocol where Self: UIViewController {
+extension ScenarioProtocol where Self: UIViewController {
     func validateScenarioSettings() -> Bool {
         if applicationId.isEmpty || accessKey.isEmpty || signatureKey.isEmpty || buildingIdentifier == 0 {
             let alertVC = UIAlertController(title: "Code Update Required", message: "Please put your applicationId/accessKey/signatureKey and buildingId in ScenarioSelectViewController.swift or the related view controllers.", preferredStyle: .alert)
@@ -29,4 +30,10 @@ extension ScenarioSettingsProtocol where Self: UIViewController {
         return true
     }
     
+    func showAlertForIndoorLocationFailure(withTitle title: String, failureMessage: String) {
+        let alertController = UIAlertController(title: title, message: failureMessage, preferredStyle: .alert)
+        let okayAction = UIAlertAction(title: "Okay", style: .default, handler: nil)
+        alertController.addAction(okayAction)
+        present(alertController, animated: true, completion: nil)
+    }
 }

--- a/Samples/MapScenarios/MapScenarios/Scenarios/BluedotLocationViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/BluedotLocationViewController.swift
@@ -12,7 +12,7 @@ import PWMapKit
 import PWCore
 
 // MARK: - BluedotLocationViewController
-class BluedotLocationViewController: UIViewController, ScenarioSettingsProtocol {
+class BluedotLocationViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -79,6 +79,18 @@ extension BluedotLocationViewController: PWMapViewDelegate {
             firstLocationAcquired = true
             mapView.trackingMode = .follow
         }
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/CustomPOIViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/CustomPOIViewController.swift
@@ -12,7 +12,7 @@ import PWMapKit
 import PWCore
 
 // MARK: - CustomPOIViewController
-class CustomPOIViewController: UIViewController, ScenarioSettingsProtocol {
+class CustomPOIViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""

--- a/Samples/MapScenarios/MapScenarios/Scenarios/LoadBuildingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/LoadBuildingViewController.swift
@@ -11,7 +11,7 @@ import PWMapKit
 import PWCore
 
 // MARK: - LoadBuildingViewController
-class LoadBuildingViewController: UIViewController, ScenarioSettingsProtocol {
+class LoadBuildingViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""

--- a/Samples/MapScenarios/MapScenarios/Scenarios/LocationModesViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/LocationModesViewController.swift
@@ -12,7 +12,7 @@ import PWMapKit
 import PWCore
 
 // MARK: - LocationModesViewController
-class LocationModesViewController: UIViewController, ScenarioSettingsProtocol {
+class LocationModesViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -102,6 +102,18 @@ extension LocationModesViewController: PWMapViewDelegate {
         @unknown default:
             break
         }
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/LocationSharingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/LocationSharingViewController.swift
@@ -98,7 +98,7 @@ extension SharedLocationAnnotationView {
 }
 
 // MARK: - LocationSharingViewController
-class LocationSharingViewController: UIViewController, ScenarioSettingsProtocol {
+class LocationSharingViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -239,6 +239,18 @@ extension LocationSharingViewController: PWMapViewDelegate {
         }
         
         return annotationView
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/OffRoute/OffRouteViewController.swift
@@ -11,7 +11,7 @@ import PWCore
 import PWMapKit
 
 // MARK: - OffRouteViewController
-class OffRouteViewController: UIViewController, ScenarioSettingsProtocol {
+class OffRouteViewController: UIViewController, ScenarioProtocol {
 
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -154,6 +154,18 @@ extension OffRouteViewController: PWMapViewDelegate {
     
     func mapView(_ mapView: PWMapView!, didChange instruction: PWRouteInstruction!) {
         turnByTurnCollectionView?.scrollToInstruction(instruction)
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/RoutingViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/RoutingViewController.swift
@@ -12,7 +12,7 @@ import PWCore
 import PWMapKit
 
 // MARK: - RoutingViewController
-class RoutingViewController: UIViewController, ScenarioSettingsProtocol {
+class RoutingViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -130,6 +130,18 @@ extension RoutingViewController: PWMapViewDelegate {
             firstLocationAcquired = true
             route()
         }
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/SearchPOIViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/SearchPOIViewController.swift
@@ -12,7 +12,7 @@ import PWMapKit
 import PWCore
 
 // MARK: - SearchPOIViewController
-class SearchPOIViewController: UIViewController, ScenarioSettingsProtocol {
+class SearchPOIViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnLandmarksViewController.swift
@@ -12,7 +12,7 @@ import PWCore
 import PWMapKit
 
 // MARK: - TurnByTurnLandmarksViewController
-class TurnByTurnLandmarksViewController: UIViewController, ScenarioSettingsProtocol {
+class TurnByTurnLandmarksViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""

--- a/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/TurnByTurnViewController.swift
@@ -11,7 +11,7 @@ import PWCore
 import PWMapKit
 
 // MARK: - TurnByTurnViewController
-class TurnByTurnViewController: UIViewController, ScenarioSettingsProtocol {
+class TurnByTurnViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""

--- a/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptRouteViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/Voice Prompt/VoicePromptRouteViewController.swift
@@ -12,7 +12,7 @@ import PWMapKit
 import UIKit
 
 // MARK: - VoicePromptRouteViewController
-class VoicePromptRouteViewController: UIViewController, ScenarioSettingsProtocol {
+class VoicePromptRouteViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -229,6 +229,18 @@ extension VoicePromptRouteViewController: PWMapViewDelegate {
         } else {
             return mapView.building.pois.first(where: { $0.identifier == destinationPOIIdentifier })
         }
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 

--- a/Samples/MapScenarios/MapScenarios/Scenarios/WalkTimeViewController.swift
+++ b/Samples/MapScenarios/MapScenarios/Scenarios/WalkTimeViewController.swift
@@ -12,7 +12,7 @@ import PWCore
 import PWMapKit
 
 // MARK: - WalkTimeViewController
-class WalkTimeViewController: UIViewController, ScenarioSettingsProtocol {
+class WalkTimeViewController: UIViewController, ScenarioProtocol {
     
     // Enter your application identifier, access key, and signature key, found on Maas portal under Account > Apps
     var applicationId = ""
@@ -185,6 +185,18 @@ extension WalkTimeViewController: PWMapViewDelegate {
         
         // restart the timer
         startWalkTimeUpdateTimer()
+    }
+    
+    func mapView(_ mapView: PWMapView!, didFailToLocateIndoorUserWithError error: Error!) {
+        guard let error = error as NSError? else {
+            return
+        }
+        
+        let title = error.domain
+        let description = error.userInfo["message"] as? String ?? "Unknown Error"
+        let message = "\(description) \n Error Code: \(error.code)"
+        
+        showAlertForIndoorLocationFailure(withTitle: title , failureMessage: message)
     }
 }
 


### PR DESCRIPTION
This has already been pushed to December-maint-release branch (by accident sry, can revert if needed) so this PR is just for reviewing purposes. 

Can use the following venue to test that Azul error reporting successfully passes up to the app, and that then the app displays the error. As of this PR this venue should be configured correctly to show the azul error (no location provider selected)

Ensure podfile is pointing to MapKitBeta

App ID:	2280
Access Key:	e51ba3eae07342dc5bd9f6ffdc7aa47aa9004f79
Signature Key:	d92be41fa8888d2614b5688d9b40b5300e90c6ba

Building ID: 78406

POI's that can be used for scenario's where they need to be injected: 51416070 and 51416069